### PR TITLE
Upstart script to run uHub as a service

### DIFF
--- a/doc/upstart/etc/init/uhub.conf
+++ b/doc/upstart/etc/init/uhub.conf
@@ -1,0 +1,28 @@
+# uHub - a lightweight but high-performance hub for the ADC
+#        peer-to-peer protocol.
+
+description "uHub - High performance ADC peer-to-peer hub"
+
+# Start and stop conditions.
+start on filesystem or runlevel [2345]
+stop on runlevel [!2345]
+
+# Allow the service to respawn, but if its happening too often
+# (10 times in 5 seconds) theres a problem and we should stop trying.
+respawn
+respawn limit 10 5
+
+# The program is going to fork, and upstart needs to know this
+# so it can track the change in PID.
+expect fork
+
+# Set the mode the process should create files in.
+umask 022
+
+# Make sure the log folder exists.
+pre-start script
+    mkdir -p -m0755 /var/log/uhub
+end script
+
+# Command to run it.
+exec /usr/bin/uhub -f -u uhub -g uhub -l /var/log/uhub/uhub.log -c /etc/uhub/uhub.conf


### PR DESCRIPTION
[Upstart](http://upstart.ubuntu.com/) is an event-based replacement for the SysV init process. It has been adopted by several Linux distributions including Ubuntu and Red Hat Enterprise Linux. 

The attached commit adds an upstart script to run uhub as a daemon. Start and stop conditions are based off the OpenSSH upstart script which ships with Ubuntu, and other options are based off the existing init script.
