### PR TITLE
Fix msg_check_escapes() so it allows escaped backslashes.

### DIFF
--- a/src/adc/message.c
+++ b/src/adc/message.c
@@ -76,6 +76,12 @@ static int msg_check_escapes(const char* string, size_t len)
                         case '\\':
                         case 'n':
                         case 's':
+                                /* Increment so we don't check the escaped
+                                * character next time around. Not doing so
+                                * leads to messages with escaped backslashes
+                                * being incorrectly reported as having invalid
+                                * escapes. */
+                                ++start;
                                 break;
                         default:
                                 return 0;


### PR DESCRIPTION
The current `msg_check_escapes()` fails to handle escaped backslashes properly. As an example, say we have the message "this is a \backslash test", which escaped is "this\sis\sa\s\\backslash\stest". The first time round, it will find the very first slash, verify the next character is an `s` and continue: "this**\s**is\sa\s\\backslash\stest". It will then start searching from the escaped `s` and handle the next couple of spaces correctly. It will then find the escaped backslash: "this\sis\sa\s**\\**backslash\stest". This is fine, but since the next search will start at the escaped backslash, the next 'escape' found will be `\b`: "this\sis\sa\s\**\b**ackslash\stest". As `\b` is not a valid ADC escape, the message will then be dropped for having an invalid ADC escape.

The fix is simple --- one line of code as in the attached commit: increment the `start` variable to skip the  escaped character in the next search.
