### PR TITLE
Add support of Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: cpp
+compiler:
+  - gcc
+  - clang
+env:
+  - CONFIG=minimal
+  - CONFIG=full
+install:
+  - autotest/travis/install-build-depends.sh
+script:
+  - autotest/travis/build-and-test.sh

--- a/autotest/travis/build-and-test.sh
+++ b/autotest/travis/build-and-test.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -x
+
+export CFLAGS="$(dpkg-buildflags --get CFLAGS) $(dpkg-buildflags --get CPPFLAGS)"
+export LDFLAGS="$(dpkg-buildflags --get LDFLAGS) -Wl,--as-needed"
+
+mkdir -p builddir
+cd builddir
+
+CMAKEOPTS="..
+           -DCMAKE_INSTALL_PREFIX=/usr"
+
+if [ "${CONFIG}" = "full" ]; then
+    CMAKEOPTS="${CMAKEOPTS}
+               -DRELEASE=OFF
+               -DLOWLEVEL_DEBUG=ON
+               -DSSL_SUPPORT=ON
+               -DUSE_OPENSSL=ON
+               -DADC_STRESS=ON"
+else
+    CMAKEOPTS="${CMAKEOPTS}
+               -DRELEASE=ON
+               -DLOWLEVEL_DEBUG=OFF
+               -DSSL_SUPPORT=OFF
+               -DADC_STRESS=OFF"
+fi
+
+
+cmake ${CMAKEOPTS} \
+      -DCMAKE_C_FLAGS="${CFLAGS}" \
+      -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}"
+make VERBOSE=1
+
+
+sudo make install
+du -shc /etc/uhub/ /usr/bin/uhub* /usr/lib/uhub/
+

--- a/autotest/travis/install-build-depends.sh
+++ b/autotest/travis/install-build-depends.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+sudo apt-get update -qq
+
+sudo apt-get install -qq cmake
+
+if [ "${CONFIG}" = "full" ]; then
+    sudo apt-get install -qq libsqlite3-dev libssl-dev
+fi
+


### PR DESCRIPTION
Travis CI will test only two configurations (minimal and full) built by two different compilers (gcc and clang). Build with GnuTLS will not be checked because it is broken now.
