### PR TITLE
Chat history sqlite fixes

### DIFF
--- a/src/plugins/mod_chat_history_sqlite.c
+++ b/src/plugins/mod_chat_history_sqlite.c
@@ -226,6 +226,8 @@ static int command_historycleanup(struct plugin_handle* plugin, struct plugin_us
 	plugin->hub.send_message(plugin, user, cbuf_get(buf));
 	cbuf_destroy(buf);
 
+	sql_execute(data, null_callback, NULL, "VACUUM;");
+
 	return 0;
 }
 


### PR DESCRIPTION
This prevents lines from being cut and cleans up the database to prevent large growth
