### PR TITLE
Allow large messages and use localtime in history

### DIFF
--- a/src/plugins/mod_chat_history_sqlite.c
+++ b/src/plugins/mod_chat_history_sqlite.c
@@ -142,7 +142,7 @@ void user_login(struct plugin_handle* plugin, struct plugin_user* user)
 	struct cbuffer* buf = NULL;
 	struct linked_list* found = (struct linked_list*) list_create();
 	
-	sql_execute(data, get_messages_callback, found, "SELECT * FROM chat_history ORDER BY time DESC LIMIT 0,%d;", (int) data->history_connect);
+	sql_execute(data, get_messages_callback, found, "SELECT from_nick,message, datetime(time, 'localtime') as time FROM chat_history ORDER BY time DESC LIMIT 0,%d;", (int) data->history_connect);
 
 	if (data->history_connect > 0 && list_size(found) > 0)
 	{
@@ -180,7 +180,7 @@ static int command_history(struct plugin_handle* plugin, struct plugin_user* use
 	else
 		maxlines = data->history_default;
 
-	sql_execute(data, get_messages_callback, found, "SELECT * FROM chat_history ORDER BY time DESC LIMIT 0,%d;", maxlines);
+	sql_execute(data, get_messages_callback, found, "SELECT from_nick,message, datetime(time, 'localtime') as time FROM chat_history ORDER BY time DESC LIMIT 0,%d;", maxlines);
 
 	size_t linecount = list_size(found);
 

--- a/src/plugins/mod_chat_history_sqlite.c
+++ b/src/plugins/mod_chat_history_sqlite.c
@@ -26,7 +26,7 @@
 #include "util/list.h"
 #include "util/cbuffer.h"
 
-#define MAX_HISTORY_SIZE 16384
+#define MAX_HISTORY_SIZE 614400
 
 struct chat_history_data
 {

--- a/src/util/cbuffer.c
+++ b/src/util/cbuffer.c
@@ -20,6 +20,7 @@
 #include "uhub.h"
 
 #define CBUF_FLAG_CONST_BUFFER 0x01
+#define MAX_MSG_LEN 16384
 
 struct cbuffer
 {
@@ -86,19 +87,19 @@ void cbuf_append(struct cbuffer* buf, const char* msg)
 
 void cbuf_append_format(struct cbuffer* buf, const char* format, ...)
 {
-	static char tmp[1024];
+	static char tmp[MAX_MSG_LEN];
 	va_list args;
 	int bytes;
 	uhub_assert(buf->flags == 0);
 	va_start(args, format);
-	bytes = vsnprintf(tmp, 1024, format, args);
+	bytes = vsnprintf(tmp, sizeof(tmp), format, args);
 	va_end(args);
 	cbuf_append_bytes(buf, tmp, bytes);
 }
 
 void cbuf_append_strftime(struct cbuffer* buf, const char* format, const struct tm* tm)
 {
-	static char tmp[1024];
+	static char tmp[MAX_MSG_LEN];
 	int bytes;
 	uhub_assert(buf->flags == 0);
 	bytes = strftime(tmp, sizeof(tmp), format, tm);


### PR DESCRIPTION
This PR uses localtime instead of utc for the sqlite chat history as well as enabeling the use of (many) large messages so your history wont be cut off.