### PR TITLE
Advertise ADC protocol with ALPN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: xenial
 compiler:
   - gcc
   - clang


### PR DESCRIPTION
Advertise ADC protocol with Application-Level Protocol Negotiation when serving TLS connections. See [proposal](https://github.com/direct-connect/protocols/blob/e92f2f0ffb955749b8c91bdd37b5c7ff60b1e25b/001-alpn.md) for more details.

This will not affect existing clients. Regardless of the ALPN negotiation outcome, the hub will continue to speak ADC.

Because of this, we don't check the result of `SSL_get0_alpn_selected`, since we won't be able to switch protocols anyway.

Still, this will help clients to detect an exact protocol version used by uhub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/janvidar/uhub/64)
<!-- Reviewable:end -->
