### PR TITLE
Add more documentation from your website to github

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -1,1 +1,0 @@
-Bugs are tracked on: https://github.com/janvidar/uhub/issues

--- a/README
+++ b/README
@@ -1,8 +1,51 @@
-Welcome and thanks for downloading uHub, a high performance ADC p2p hub.
+# Uhub
 
-For the official documentation, bugs and other information, please visit:
-https://www.uhub.org/
+Uhub is a high performance peer-to-peer hub for the ADC network. Its low memory footprint allows it to handle several thousand users on high-end servers, or a small private hub on embedded hardware.  
+Uhub uses the ADC protocol, and is compatible with DC++, jUCy and other ADC clients.
+
+## Key features
+
+ - High performance and low memory usage
+ - IPv4 and IPv6 support
+ - Experimental SSL support (optional)
+ - Advanced access control support
+ - Easy configuration
+
+## Download
+
+### Zip files
+
+The latest version is 0.5.0, released Friday 17, October 2014.  
+You can find zip / tar.gz file on https://github.com/janvidar/uhub/releases
+
+### Git
+
+You can also use git to use the last up-to-date version: 
+ $ git clone https://github.com/janvidar/uhub.git
+ 
+### Ubuntu and Debian packages
+
+Tehnick has provided an up to date uhub PPA for Debian and Ubuntu based distributions: https://tehnick.github.io/uhub/
+
+## Documentation
+
+### Compile
+
+See doc/compile.txt document.
+
+### Getting started
+
+See doc/getstarted.txt document.
+
+### Use SSL
+
+See doc/ssl-documentation.txt document.
+
+## Compatible clients
 
 For a list of compatible ADC clients, see:
 https://en.wikipedia.org/wiki/Comparison_of_ADC_software#Client_software
 
+## License
+
+Uhub is free and open source software, licensed under the GNU General Public License 3 (see COPYING file).

--- a/README
+++ b/README
@@ -13,16 +13,11 @@ Uhub uses the ADC protocol, and is compatible with DC++, jUCy and other ADC clie
 
 ## Download
 
-### Zip files
-
-The latest version is 0.5.0, released Friday 17, October 2014.  
-You can find zip / tar.gz file on https://github.com/janvidar/uhub/releases
-
-### Git
-
 You can also use git to use the last up-to-date version: 
  $ git clone https://github.com/janvidar/uhub.git
- 
+
+You can also find zip / tar.gz files of different uhub versions on https://github.com/janvidar/uhub/releases
+
 ### Ubuntu and Debian packages
 
 Tehnick has provided an up to date uhub PPA for Debian and Ubuntu based distributions: https://tehnick.github.io/uhub/
@@ -31,15 +26,15 @@ Tehnick has provided an up to date uhub PPA for Debian and Ubuntu based distribu
 
 ### Compile
 
-See doc/compile.txt document.
+See doc/compile.txt document or https://github.com/janvidar/uhub/blob/master/doc/compile.txt.
 
 ### Getting started
 
-See doc/getstarted.txt document.
+See doc/getstarted.txt document or https://github.com/janvidar/uhub/blob/master/doc/getstarted.txt.
 
 ### Use SSL
 
-See doc/ssl-documentation.txt document.
+See doc/ssl-documentation.txt document or https://github.com/janvidar/uhub/blob/master/doc/ssl-documentation.txt.
 
 ## Compatible clients
 
@@ -48,4 +43,5 @@ https://en.wikipedia.org/wiki/Comparison_of_ADC_software#Client_software
 
 ## License
 
-Uhub is free and open source software, licensed under the GNU General Public License 3 (see COPYING file).
+Uhub is free and open source software, licensed under the GNU General Public License 3.
+See COPYING file, https://github.com/janvidar/uhub/blob/master/COPYING or directly https://www.gnu.org/licenses/gpl-3.0.txt

--- a/doc/compile.txt
+++ b/doc/compile.txt
@@ -1,9 +1,6 @@
-How to compile:
----------------
+# How to compile:
 
-See the official compiling howto: https://www.uhub.org/compile.php
-
-Prerequisites
+## Prerequisites
 
 Before you try to compile µHub, please make sure the following prerequisites are met.
   * GNU make
@@ -12,15 +9,22 @@ Before you try to compile µHub, please make sure the following prerequisites ar
   * openssl > 0.9.8 (or use  "make USE_SSL=NO")
   * sqlite > 3.x
 
-or read  https://www.uhub.org/compile.php for more info.
+For Ubuntu / Debian:
 
+ $ sudo apt-get install cmake make gcc git libsqlite3-dev libssl-dev
 
-Linux, Mac OSX, FreeBSD, NetBSD and OpenBSD
--------------------------------------------
-Simply, run:
-  % make 
+## Linux, Mac OSX, FreeBSD, NetBSD and OpenBSD
 
+ $ cmake .
+ $ make
+ % make install
+ 
 If you have an old gcc compiler, try disabling pre-compiled headers like this:
 gmake USE_PCH=NO
 
+### Default install directories:
 
+Binaries 	/usr/local/bin/
+Configuration files 	/etc/uhub/
+Plugins 	/usr/lib/uhub/
+Manual pages 	/usr/share/man/man1/

--- a/doc/getstarted.txt
+++ b/doc/getstarted.txt
@@ -1,17 +1,11 @@
-Getting started guide
----------------------
+# Getting started guide
 
-Unpack your binaries 
+## Compile it at first
 
-Example:
-  % tar xzf uhub-0.2.6-linux-i386.tar.gz
-  % cd uhub-0.2.6
+See the doc/compile.txt file
 
-Copy the binary to /usr/local/bin
+## Create configuration files
 
-  % sudo cp uhub /usr/local/bin
-
-Create configuration files.
 If no configuration files are created, uhub will use the default parameters, so you can skip this step if you are in a hurry to see it run.
 
 As root, or use sudo.
@@ -20,6 +14,19 @@ As root, or use sudo.
   % cp doc/uhub.conf /etc/uhub
   % cp doc/users.conf /etc/uhub
   % echo "welcome to uhub" > /etc/uhub/motd.txt
+  
+You can edit the default configuration file before starting uhub.
+As root edit /etc/uhub/uhub.conf: 
+
+  hub_name=My Public Hub
+  hub_description=Yet another ADC hub
+  
+  server_port=1511
+  server_bind_addr=any
+  max_users=150
+
+
+## Start uhub
 
 Start the hub in the foreground for the first time. Shut it down, by pressing CTRL+C.
 
@@ -27,7 +34,10 @@ Start the hub in the foreground for the first time. Shut it down, by pressing CT
   Thu, 05 Feb 2009 00:48:04 +0000 INFO: Starting server, listening on :::1511...
 
 Connect to the hub using an ADC client, use the address adc://localhost:1511, or replace localhost with the correct hostname or IP address.
-NOTE: It is important to use the "adc://" prefix, and the port number when using DC++ and other ADC clients.
+
+**NOTE**: It is important to use the "adc://" prefix, and the port number.
+
+## Kill / Stop uhub
 
 If you modify the configuration files in /etc/uhub you will have to notify uhub by sending a HUP signal.
 
@@ -38,6 +48,8 @@ Or, for the lazy people
 
   % killall -HUP uhub
 
+## Start uhub as daemon (or in background mode)
+
 In order to run uhub as a daemon, start it with the -f switch which will make it fork into the background.
 In addition, use the -l to specify a log file instead of stdout. One can also specify a specific user and/or group, 
 if one wishes to run uhub as a specific user using the -u and -g switches.
@@ -46,22 +58,25 @@ Example:
 
   % uhub -f -l mylog.txt -u nobody -g nogroup
 
-If you are planning to more than 1024 users on hub, you must increase the max number of file descriptors allowed.
+## Having more than 1024 users on uhub
+
+If you are planning to more than 1024 users on your hub, you must increase the max number of file descriptors allowed.  
 This limit needs to be higher than the configured max_users in uhub.conf.
 
 In Linux can add the following lines to /etc/security/limits.conf (allows for ~4000 users)
-      *     soft nofile 4096
-      *     hard nofile 4096
+      * soft nofile 4096
+      * hard nofile 4096
 
 Or, you can use (as root):
 
   % ulimit -n 4096
 
+## Interact with uhub through your hub chat (only for operator/admin):
+
 You can interact with uhub in your hub main chat using the `!` prefix, followed by a command:
 
-Example :
+Example, to display help and the command you can use:
 
-      *     to display help and the command you can use:
-            !help 
-                     
+      * !help
+            
 Your mileage may vary -- Good luck!

--- a/doc/ssl-documentation.txt
+++ b/doc/ssl-documentation.txt
@@ -1,0 +1,70 @@
+# Setting up an SSL hub
+
+## About certificates
+
+Before you can setup an SSL protected hub, you must create an SSL certificate for the hub.
+NOTE: uhub must be compiled with SSL support enabled in order for this to work (enabled by default, but not for Windows).
+
+## Configuring uhub
+
+If you have your certificates ready, just set these configuration values in uhub.conf file:
+
+  tls_private_key="/path/to/domainname.key"
+  tls_certificate="/path/to/domainname.crt"
+  tls_enable=yes
+  tls_require=yes
+ 
+Now you can connect to the hub using the adcs:// protocol handle.
+
+## Creating certificates
+
+### Creating a self-signed certificate
+
+To create self-signed certificates with an 2048 bits RSA private key using the following command:
+
+ $ openssl genrsa -out domainname.key 2048
+
+Then create the certificate (valid for 365 days, using sha256):
+
+ $ openssl req -new -x509 -nodes -sha256 -days 365 -key domainname.key > domainname.crt
+
+At this point point you will be prompted a few questions, see the section Certificate data below.
+
+## Creating a certificate with a CA
+
+Create an 2048 bits RSA private key using the following command:
+
+ $ openssl genrsa -out domainname.key 2048
+
+Then create a Certificate Signing Request (csr):
+
+ $ openssl req -new -key domainname.key -out domainname.csr
+
+See the "Certificate data" section below for answering the certificate questions.
+
+After this is done, you should send the domainname.csr to your CA for signing, and when the transaction is done you get the certificate from the CA.
+Save the certificate as dommainname.crt.
+
+## Certificate data
+
+When creating a certificate, you are asked a series of questions, follow this guide:
+
+    Two letter country code. Example: DE.
+    State or Province Name. Example: Bavaria
+    Locality Name. Example: Munich
+    Organization Name. The name of your organization or company. Use your name if this certificate is not for any organization)
+    Organizational Unit Name. The name of your department within your organization, like sysadmin, etc. (can be left blank)
+    Common Name. The hostname of your server. Example: secure.extatic.org
+    Your e-mail address
+
+## Giving fingerprint
+
+Now that you have ssl activated on your hub, you may have to share the certificate fingerprint to your hub user:
+
+Find it by using this commandline:
+
+ $ openssl x509 -noout -fingerprint -sha256 < "/path/to/domainname.crt" | cut -d '=' -f 2 | tr -dc "[A-F][0-9]" | xxd -r -p | base32 | tr -d "="
+ 
+And give your full uhub address:
+
+adc://localhost:1511?kp=SHA256/THE_VALUE_RETURNED_BY_COMMANDLINE_ABOVE

--- a/doc/ssl-documentation.txt
+++ b/doc/ssl-documentation.txt
@@ -67,4 +67,4 @@ Find it by using this commandline:
  
 And give your full uhub address:
 
-adc://localhost:1511?kp=SHA256/THE_VALUE_RETURNED_BY_COMMANDLINE_ABOVE
+adcs://localhost:1511?kp=SHA256/THE_VALUE_RETURNED_BY_COMMANDLINE_ABOVE


### PR DESCRIPTION
I've imported and improved uhub documentation by using the one from your website.

[Plug-ins documentation](https://uhub.org/doc/plugins/) is still missing in your repositories sadly