### PR TITLE
Change event filter from READ to WRITE on deletion

### DIFF
--- a/src/network/kqueue.c
+++ b/src/network/kqueue.c
@@ -268,7 +268,7 @@ static size_t create_change_list(struct net_backend_kqueue* backend)
 		else
 		{
 			EV_SET(&backend->changes[changes++], sd, EVFILT_READ, EV_DELETE, 0, 0, 0);
-			EV_SET(&backend->changes[changes++], sd, EVFILT_READ, EV_DELETE, 0, 0, 0);
+			EV_SET(&backend->changes[changes++], sd, EVFILT_WRITE, EV_DELETE, 0, 0, 0);
 		}
 	}
 	backend->change_list_len = 0;


### PR DESCRIPTION
In the kqueue backend's `create_change_list()` function, when a connection is being removed (the `con` pointer is NULL because the connection has been destroyed), both `EV_SET` calls use `EVFILT_READ`:

```c
// kqueue.c:272-275
else
{
    EV_SET(&backend->changes[changes++], sd, EVFILT_READ, EV_DELETE, 0, 0, 0);
    EV_SET(&backend->changes[changes++], sd, EVFILT_READ, EV_DELETE, 0, 0, 0);  // BUG!
}
```

The second `EV_SET` should use `EVFILT_WRITE` to delete the write event filter from the kernel kqueue. Instead, it duplicates the read filter deletion.