### PR TITLE
Improve buffer resizing logic in cbuffer.c

### DIFF
--- a/src/util/cbuffer.c
+++ b/src/util/cbuffer.c
@@ -90,7 +90,7 @@ void cbuf_append_bytes(struct cbuffer* buf, const char* msg, size_t len)
 	if (new_size >= buf->capacity)
 	{
 		cbuf_resize(buf, new_size);
-		if (new_size >= buf->capacity)  /* resize failed */
+		if (new_size > buf->capacity)  /* resize failed */
 			return;
 	}
 

--- a/src/util/cbuffer.c
+++ b/src/util/cbuffer.c
@@ -88,11 +88,11 @@ void cbuf_append_bytes(struct cbuffer* buf, const char* msg, size_t len)
 
 	new_size = buf->size + len;
 	if (new_size >= buf->capacity)
+	{
 		cbuf_resize(buf, new_size);
-
-	/* Verify resize succeeded */
-	if (new_size >= buf->capacity)
-		return;
+		if (new_size >= buf->capacity)  /* resize failed */
+			return;
+	}
 
 	memcpy(buf->buf + buf->size, msg, len);
 	buf->size = new_size;


### PR DESCRIPTION
Refactor buffer resizing logic to ensure it only checks capacity after attempting to resize.