### PR TITLE
mod_ucmd: publish hub commands as ADC user-command context menus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ add_library(mod_chat_history MODULE ${UHUB_SOURCE_DIR}/plugins/mod_chat_history.
 add_library(mod_chat_history_sqlite MODULE ${UHUB_SOURCE_DIR}/plugins/mod_chat_history_sqlite.c)
 add_library(mod_chat_only MODULE ${UHUB_SOURCE_DIR}/plugins/mod_chat_only.c)
 add_library(mod_topic MODULE ${UHUB_SOURCE_DIR}/plugins/mod_topic.c)
+add_library(mod_ucmd MODULE ${UHUB_SOURCE_DIR}/plugins/mod_ucmd.c)
 add_library(mod_no_guest_downloads MODULE ${UHUB_SOURCE_DIR}/plugins/mod_no_guest_downloads.c)
 add_library(mod_flood MODULE ${UHUB_SOURCE_DIR}/plugins/mod_flood.c)
 add_library(mod_auth_sqlite MODULE ${UHUB_SOURCE_DIR}/plugins/mod_auth_sqlite.c)
@@ -272,6 +273,7 @@ set_target_properties(
 	mod_no_guest_downloads
 	mod_flood
 	mod_topic
+	mod_ucmd
 	PROPERTIES PREFIX "")
 
 target_link_libraries(uhub ${CMAKE_DL_LIBS} adc network utils)
@@ -288,6 +290,7 @@ target_link_libraries(mod_flood utils)
 target_link_libraries(mod_chat_only utils)
 target_link_libraries(mod_logging network utils)
 target_link_libraries(mod_topic utils)
+target_link_libraries(mod_ucmd utils)
 
 if(WIN32)
 	target_link_libraries(uhub ws2_32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project (uhub
-	VERSION 0.7.0
+	VERSION 0.7.1
 	LANGUAGES C)
 
 # Build everything as C23 (gnu23 - _GNU_SOURCE and friends are still needed).

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+0.7.1:
+New features:
+- New plugin mod_ucmd: publishes the hub's registered commands as ADC user-command (UCMD) context-menu entries for clients that support the UCM0 extension. Every command available at a user's credential level appears in the client's right-click menu — user-targeting commands (kick, ban, getip, ...) in the user-list menu and the rest in the hub menu — and selecting an entry sends the corresponding +command on the user's behalf.
+
+Plugin API:
+- Added a command_foreach() hub callback (and a read-only plugin_command_info view) so plugins can enumerate the registered hub commands available to a given credential level.
+
 0.7.0:
 Federation and scaling:
 - Hub linking: multiple uhubs can be linked into a single logical hub with a partitioned SID space, a dedicated hub-to-hub link protocol (challenge-response authenticated with a shared secret), and cross-hub routing of chat, private messages, searches, results and connect requests. Links reuse the normal client port and are auto-detected.

--- a/autotest/test_commands.tcc
+++ b/autotest/test_commands.tcc
@@ -229,6 +229,30 @@ EXO_TEST(command_argument_cred_6, {
 
 #undef SETUP_COMMAND
 
+/* !redirect: registration, access level and argument parsing (user "tester"
+ * is registered in the hub at this point). */
+EXO_TEST(command_redirect_parse_ok,      { user.credentials = auth_cred_operator; return verify("!redirect tester adc://host.example:411", cmd_status_ok); });
+EXO_TEST(command_redirect_missing_addr,  { return verify("!redirect tester", cmd_status_missing_args); });
+EXO_TEST(command_redirect_unknown_nick,  { return verify("!redirect nosuchuser adc://host:411", cmd_status_arg_nick); });
+EXO_TEST(command_redirect_access,        { user.credentials = auth_cred_guest; return verify("!redirect tester adc://host:411", cmd_status_access_error); });
+
+/* !redirect: address validation (command_redirect_valid_address). */
+EXO_TEST(command_redirect_addr_adc,          { return command_redirect_valid_address("adc://host.example:411") == 1; });
+EXO_TEST(command_redirect_addr_adcs,         { return command_redirect_valid_address("adcs://host.example:412") == 1; });
+EXO_TEST(command_redirect_addr_dchub,        { return command_redirect_valid_address("dchub://old.example:411") == 1; });
+EXO_TEST(command_redirect_addr_ipv6,         { return command_redirect_valid_address("adc://[::1]:411") == 1; });
+EXO_TEST(command_redirect_addr_ipv4_maxport, { return command_redirect_valid_address("adc://1.2.3.4:65535") == 1; });
+EXO_TEST(command_redirect_addr_bad_scheme,   { return command_redirect_valid_address("http://host:411") == 0; });
+EXO_TEST(command_redirect_addr_no_scheme,    { return command_redirect_valid_address("host:411") == 0; });
+EXO_TEST(command_redirect_addr_no_port,      { return command_redirect_valid_address("adc://host") == 0; });
+EXO_TEST(command_redirect_addr_empty_host,   { return command_redirect_valid_address("adc://:411") == 0; });
+EXO_TEST(command_redirect_addr_port_zero,    { return command_redirect_valid_address("adc://host:0") == 0; });
+EXO_TEST(command_redirect_addr_port_high,    { return command_redirect_valid_address("adc://host:99999") == 0; });
+EXO_TEST(command_redirect_addr_port_nan,     { return command_redirect_valid_address("adc://host:abc") == 0; });
+EXO_TEST(command_redirect_addr_space,        { return command_redirect_valid_address("adc://ho st:411") == 0; });
+EXO_TEST(command_redirect_addr_plain,        { return command_redirect_valid_address("justtext") == 0; });
+EXO_TEST(command_redirect_addr_empty,        { return command_redirect_valid_address("") == 0; });
+
 EXO_TEST(command_user_destroy, { return uman_remove(hub->users, &user) == 0; });
 
 EXO_TEST(command_destroy, {

--- a/build.zig
+++ b/build.zig
@@ -113,6 +113,7 @@ const plugins = [_]Plugin{
     .{ .name = "mod_chat_history_sqlite", .sqlite = true },
     .{ .name = "mod_chat_only" },
     .{ .name = "mod_topic" },
+    .{ .name = "mod_ucmd" },
     .{ .name = "mod_no_guest_downloads" },
     .{ .name = "mod_flood" },
 };

--- a/build.zig
+++ b/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 // Keep these in sync with CMakeLists.txt (UHUB_VERSION_*).
 const version_major = 0;
 const version_minor = 7;
-const version_patch = 0;
+const version_patch = 1;
 
 // Shared source sets, mirroring the static libraries CMakeLists.txt builds
 // (adc / network / utils). They are compiled once into a single static

--- a/doc/plugins.conf
+++ b/doc/plugins.conf
@@ -32,6 +32,15 @@ plugin /usr/lib/uhub/mod_auth_sqlite.so "file=/etc/uhub/users.db"
 # This plugins takes no parameters.
 #plugin /usr/lib/uhub/mod_topic.so
 
+# User-command (UCMD) context menus.
+#
+# Publishes a set of hub commands as ADC right-click context-menu entries in
+# clients that support the UCM0 extension (DC++, AirDC++, etc.). Selecting an
+# entry makes the client send the corresponding "+command" on the user's behalf.
+#
+# This plugin takes no parameters.
+#plugin /usr/lib/uhub/mod_ucmd.so
+
 # Log file writer
 #
 # Parameters:

--- a/src/adc/adcconst.h
+++ b/src/adc/adcconst.h
@@ -35,7 +35,7 @@ typedef uint32_t fourcc_t;
 #define FOURCC(a,b,c,d) (fourcc_t) (((uint32_t)(unsigned char)(a) << 24) | ((uint32_t)(unsigned char)(b) << 16) | ((uint32_t)(unsigned char)(c) << 8) | (uint32_t)(unsigned char)(d))
 
 /* default welcome protocol support message, as sent by this server */
-#define ADC_PROTO_SUPPORT "ADBASE ADTIGR ADPING ADNATT"
+#define ADC_PROTO_SUPPORT "ADBASE ADTIGR ADPING ADNATT UCM0"
 
 /* Server sent commands */
 #define ADC_CMD_ISID FOURCC('I','S','I','D')

--- a/src/core/commands.c
+++ b/src/core/commands.c
@@ -378,6 +378,83 @@ static int command_kick(struct command_base* cbase, struct hub_user* user, struc
 	return command_status(cbase, user, cmd, buf);
 }
 
+/* Accept only adc://host:port, adcs://host:port or dchub://host:port, with a
+ * non-empty host (hostname / IPv4 / bracketed IPv6) and a numeric port in
+ * 1..65535. Restricting the character set keeps the value safe to place in an
+ * ADC RD flag without further escaping. */
+int command_redirect_valid_address(const char* addr)
+{
+	static const char* const schemes[] = { "adc://", "adcs://", "dchub://", NULL };
+	const char* host = NULL;
+	const char* colon;
+	const char* p;
+	size_t i;
+	long port;
+
+	if (!addr || !*addr || strlen(addr) > 255)
+		return 0;
+
+	for (i = 0; schemes[i]; i++)
+	{
+		size_t len = strlen(schemes[i]);
+		if (!strncmp(addr, schemes[i], len))
+		{
+			host = addr + len;
+			break;
+		}
+	}
+	if (!host)
+		return 0;
+
+	/* Rightmost ':' splits host from port, so bracketed IPv6 ([::1]:411) works. */
+	colon = strrchr(host, ':');
+	if (!colon || colon == host)
+		return 0;
+
+	for (p = host; p < colon; p++)
+	{
+		char c = *p;
+		if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+		      (c >= '0' && c <= '9') || c == '.' || c == '-' ||
+		      c == ':' || c == '[' || c == ']'))
+			return 0;
+	}
+
+	for (p = colon + 1; *p; p++)
+		if (*p < '0' || *p > '9')
+			return 0;
+
+	port = strtol(colon + 1, NULL, 10);
+	if (port < 1 || port > 65535)
+		return 0;
+
+	return 1;
+}
+
+static int command_redirect(struct command_base* cbase, struct hub_user* user, struct hub_command* cmd)
+{
+	struct cbuffer* buf = cbuf_create(256);
+	struct hub_command_arg_data* arg_user = hub_command_arg_next(cmd, type_user);
+	struct hub_command_arg_data* arg_addr = hub_command_arg_next(cmd, type_string);
+	struct hub_user* target = arg_user->data.user;
+	const char* address = arg_addr->data.string;
+
+	if (target == user)
+	{
+		cbuf_append(buf, "Cannot redirect yourself.");
+	}
+	else if (!command_redirect_valid_address(address))
+	{
+		cbuf_append_format(buf, "Invalid redirect address \"%s\". Expected adc://host:port, adcs://host:port or dchub://host:port.", address);
+	}
+	else
+	{
+		cbuf_append_format(buf, "Redirecting user \"%s\" to %s.", target->id.nick, address);
+		hub_redirect_user(cbase->hub, target, address);
+	}
+	return command_status(cbase, user, cmd, buf);
+}
+
 static int command_ban(struct command_base* cbase, struct hub_user* user, struct hub_command* cmd)
 {
 	struct cbuffer* buf;
@@ -644,6 +721,7 @@ void commands_builtin_add(struct command_base* cbase)
 	ADD_COMMAND("help",       4, "?c",auth_cred_guest,     command_help,     "Show this help message."      );
 	ADD_COMMAND("ban",        3, "u", auth_cred_operator,  command_ban,      "Ban a user (cluster-wide)"    );
 	ADD_COMMAND("kick",       4, "u", auth_cred_operator,  command_kick,     "Kick a user"                  );
+	ADD_COMMAND("redirect",   8, "um",auth_cred_operator,  command_redirect, "Redirect a user to another hub");
 	ADD_COMMAND("log",        3, "?m",auth_cred_operator,  command_log,      "Display log"                  ); // fail
 	ADD_COMMAND("myip",       4, "",  auth_cred_guest,     command_myip,     "Show your own IP."            );
 	ADD_COMMAND("reload",     6, "",  auth_cred_admin,     command_reload,   "Reload configuration files."  );

--- a/src/core/commands.c
+++ b/src/core/commands.c
@@ -118,6 +118,17 @@ struct command_handle* command_handler_lookup(struct command_base* cbase, const 
 }
 
 
+void command_foreach(struct command_base* cbase, enum auth_credentials credentials, command_handle_enum handler, void* ptr)
+{
+	struct command_handle* command = NULL;
+	LIST_FOREACH(struct command_handle*, command, cbase->handlers,
+	{
+		if (command_is_available(command, credentials))
+			handler(command, ptr);
+	});
+}
+
+
 void command_get_syntax(struct command_handle* handler, struct cbuffer* buf)
 {
 	size_t n, arg_count;

--- a/src/core/commands.h
+++ b/src/core/commands.h
@@ -103,6 +103,12 @@ extern int command_invoke(struct command_base*, struct hub_user* user, const cha
 int command_is_available(struct command_handle* handle, enum auth_credentials credentials);
 
 /**
+ * Returns 1 if @p addr is a valid hub redirect address (adc://host:port,
+ * adcs://host:port or dchub://host:port), 0 otherwise. Exposed for testing.
+ */
+int command_redirect_valid_address(const char* addr);
+
+/**
  * Lookup a command handle based on prefix.
  * If no matching command handle is found then NULL is returned.
  */

--- a/src/core/commands.h
+++ b/src/core/commands.h
@@ -108,6 +108,17 @@ int command_is_available(struct command_handle* handle, enum auth_credentials cr
  */
 struct command_handle* command_handler_lookup(struct command_base* cbase, const char* prefix);
 
+/**
+ * Callback type for command_foreach().
+ */
+typedef void (*command_handle_enum)(struct command_handle*, void* ptr);
+
+/**
+ * Invoke @p handler once for every registered command that is available to a
+ * user holding the given @p credentials (as per command_is_available()).
+ */
+void command_foreach(struct command_base* cbase, enum auth_credentials credentials, command_handle_enum handler, void* ptr);
+
 extern void commands_builtin_add(struct command_base*);
 extern void commands_builtin_remove(struct command_base*);
 

--- a/src/core/hub.c
+++ b/src/core/hub.c
@@ -1411,6 +1411,28 @@ void hub_send_status(struct hub_info* hub, struct hub_user* user, enum status_me
 	adc_msg_free(qui);
 }
 
+void hub_redirect_user(struct hub_info* hub, struct hub_user* user, const char* address)
+{
+	struct adc_message* qui = adc_msg_construct(ADC_CMD_IQUI, 512);
+	char buf[300];
+
+	if (!qui)
+		return;
+
+	/* Tell the client to reconnect elsewhere: an IQUI carrying the user's own
+	 * SID plus an RD (redirect) flag, mirroring the redirect path in
+	 * hub_send_status(). The caller has validated the address, so it needs no
+	 * escaping. The message is routed before the disconnect, whose pre-close
+	 * flush pushes it to the socket. */
+	adc_msg_add_argument(qui, sid_to_string(user->id.sid));
+	snprintf(buf, sizeof(buf), "RD%s", address);
+	adc_msg_add_argument(qui, buf);
+	route_to_user(hub, user, qui);
+	adc_msg_free(qui);
+
+	hub_disconnect_user(hub, user, quit_disconnected);
+}
+
 const char* hub_get_status_message(struct hub_info* hub, enum status_message msg)
 {
 #define STATUS(MSG) case status_ ## MSG : return cfg->MSG; break

--- a/src/core/hub.h
+++ b/src/core/hub.h
@@ -249,6 +249,13 @@ extern void hub_send_password_challenge(struct hub_info* hub, struct hub_user* u
 extern void hub_send_status(struct hub_info*, struct hub_user* user, enum status_message msg, enum msg_status_level level);
 
 /**
+ * Redirect a user to another hub: sends an IQUI with an RD (redirect) flag
+ * pointing at @p address, then disconnects the user. @p address is expected to
+ * be a validated adc:// / adcs:// / dchub:// URL.
+ */
+extern void hub_redirect_user(struct hub_info* hub, struct hub_user* user, const char* address);
+
+/**
  * Warn user about flooding.
  */
 extern void hub_send_flood_warning(struct hub_info*, struct hub_user* user, const char* message);

--- a/src/core/plugincallback.c
+++ b/src/core/plugincallback.c
@@ -132,6 +132,25 @@ static int cbfunc_send_status(struct plugin_handle* plugin, struct plugin_user* 
 	return 1;
 }
 
+static int cbfunc_send_user_command(struct plugin_handle* plugin, struct plugin_user* user, const char* name, int context, const char* command)
+{
+	char* esc_name = adc_msg_escape(name);
+	struct adc_message* msg = adc_msg_construct(ADC_CMD_ICMD, strlen(esc_name) + (command ? strlen(command) : 0) + 32);
+	adc_msg_add_argument(msg, esc_name);                 /* positional: menu name (submenus split by '/') */
+	if (command)
+	{
+		char* esc_cmd = adc_msg_escape(command);
+		adc_msg_add_named_argument(msg, "TT", esc_cmd);  /* TT: the line the client sends when chosen */
+		hub_free(esc_cmd);
+	}
+	if (context)
+		adc_msg_add_named_argument_int(msg, "CT", context); /* CT: context bitfield (1=hub 2=user 4=search 8=file) */
+	route_to_user(plugin_get_hub(plugin), as_hub_user(user), msg);
+	adc_msg_free(msg);
+	hub_free(esc_name);
+	return 1;
+}
+
 static int cbfunc_user_disconnect(struct plugin_handle* plugin, struct plugin_user* user)
 {
 	hub_disconnect_user(plugin_get_hub(plugin), as_hub_user(user), quit_kicked);
@@ -167,6 +186,36 @@ static int cbfunc_command_del(struct plugin_handle* plugin, struct plugin_comman
 	hub_free(command);
 	cmdh->internal_handle = NULL;
 	return 0;
+}
+
+struct command_foreach_data
+{
+	struct plugin_handle* plugin;
+	hfunc_command_foreach_callback callback;
+	void* ptr;
+};
+
+static void command_foreach_trampoline(struct command_handle* command, void* ptr)
+{
+	struct command_foreach_data* data = (struct command_foreach_data*) ptr;
+	struct plugin_command_info info;
+
+	info.prefix = command->prefix;
+	info.args = command->args;
+	info.cred = command->cred;
+	info.description = command->description;
+	info.origin = command->origin;
+
+	data->callback(data->plugin, &info, data->ptr);
+}
+
+static void cbfunc_command_foreach(struct plugin_handle* plugin, enum auth_credentials credentials, hfunc_command_foreach_callback callback, void* ptr)
+{
+	struct command_foreach_data data;
+	data.plugin = plugin;
+	data.callback = callback;
+	data.ptr = ptr;
+	command_foreach(plugin_get_hub(plugin)->commands, credentials, command_foreach_trampoline, &data);
 }
 
 size_t cbfunc_command_arg_reset(struct plugin_handle* plugin, struct plugin_command* cmd)
@@ -237,9 +286,11 @@ void plugin_register_callback_functions(struct plugin_handle* handle)
 	handle->hub.send_message = cbfunc_send_message;
 	handle->hub.send_broadcast_message = cbfunc_send_broadcast;
 	handle->hub.send_status_message = cbfunc_send_status;
+	handle->hub.send_user_command = cbfunc_send_user_command;
 	handle->hub.user_disconnect = cbfunc_user_disconnect;
 	handle->hub.command_add = cbfunc_command_add;
 	handle->hub.command_del = cbfunc_command_del;
+	handle->hub.command_foreach = cbfunc_command_foreach;
 	handle->hub.command_arg_reset = cbfunc_command_arg_reset;
 	handle->hub.command_arg_next = cbfunc_command_arg_next;
 	handle->hub.get_usercount = cbfunc_get_usercount;

--- a/src/plugin_api/command_api.h
+++ b/src/plugin_api/command_api.h
@@ -60,6 +60,20 @@ struct plugin_command_arg_data
 
 typedef int (*plugin_command_handler)(struct plugin_handle*, struct plugin_user* to, struct plugin_command*);
 
+/**
+ * Read-only view of a registered command, as passed to the enumeration
+ * callback of the command_foreach() hub function. Mirrors the public fields of
+ * the core command_handle without exposing the hub-internal ones.
+ */
+struct plugin_command_info
+{
+	const char* prefix;             /**<<< "Command prefix, e.g. 'kick' for the !kick command." */
+	const char* args;               /**<<< "Argument codes (see argument documentation above)." */
+	enum auth_credentials cred;     /**<<< "Minimum access level required to use the command." */
+	const char* description;        /**<<< "Human-readable description of the command." */
+	const char* origin;             /**<<< "Name of the module the command originates from." */
+};
+
 struct plugin_command_handle
 {
 	void* internal_handle;          /**<<< "Internal used by the hub only" */

--- a/src/plugin_api/handle.h
+++ b/src/plugin_api/handle.h
@@ -116,9 +116,13 @@ struct plugin_command_arg_data;
 typedef int (*hfunc_send_message)(struct plugin_handle*, struct plugin_user* user, const char* message);
 typedef int (*hfunc_send_broadcast_message)(struct plugin_handle*, const char* message);
 typedef int (*hfunc_send_status)(struct plugin_handle*, struct plugin_user* to, int code, const char* message);
+typedef int (*hfunc_send_user_command)(struct plugin_handle*, struct plugin_user* user, const char* name, int context, const char* command);
 typedef int (*hfunc_user_disconnect)(struct plugin_handle*, struct plugin_user* user);
 typedef int (*hfunc_command_add)(struct plugin_handle*, struct plugin_command_handle*);
 typedef int (*hfunc_command_del)(struct plugin_handle*, struct plugin_command_handle*);
+
+typedef void (*hfunc_command_foreach_callback)(struct plugin_handle*, const struct plugin_command_info*, void* ptr);
+typedef void (*hfunc_command_foreach)(struct plugin_handle*, enum auth_credentials credentials, hfunc_command_foreach_callback callback, void* ptr);
 
 typedef size_t (*hfunc_command_arg_reset)(struct plugin_handle*, struct plugin_command*);
 typedef struct plugin_command_arg_data* (*hfunc_command_arg_next)(struct plugin_handle*, struct plugin_command*, enum plugin_command_arg_type);
@@ -139,9 +143,11 @@ struct plugin_hub_funcs
 	hfunc_send_message send_message;
 	hfunc_send_broadcast_message send_broadcast_message;
 	hfunc_send_status send_status_message;
+	hfunc_send_user_command send_user_command;
 	hfunc_user_disconnect user_disconnect;
 	hfunc_command_add command_add;
 	hfunc_command_del command_del;
+	hfunc_command_foreach command_foreach;
 	hfunc_command_arg_reset command_arg_reset;
 	hfunc_command_arg_next command_arg_next;
 	hfunc_get_usercount get_usercount;

--- a/src/plugin_api/types.h
+++ b/src/plugin_api/types.h
@@ -26,7 +26,7 @@
 #include "util/credentials.h"
 #include "network/ipcalc.h"
 
-#define PLUGIN_API_VERSION 2
+#define PLUGIN_API_VERSION 3
 
 struct plugin_handle;
 

--- a/src/plugins/mod_ucmd.c
+++ b/src/plugins/mod_ucmd.c
@@ -1,0 +1,133 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "system.h"
+#include "adc/adcconst.h"
+#include "util/memory.h"
+#include "plugin_api/handle.h"
+
+/* ADC UCMD context bitfield (the "CT" field of an ICMD). */
+#define UCMD_CT_HUB     1   /* hub / main-chat menu  */
+#define UCMD_CT_USER    2   /* userlist / chat menu  */
+#define UCMD_CT_SEARCH  4   /* search-results menu   */
+#define UCMD_CT_FILE    8   /* filelist / transfer   */
+
+/*
+ * Every registered hub command is published as a UCMD context-menu entry. For
+ * each command, the client transmits, when the entry is chosen, the line built
+ * in emit_command(): a BMSG from the user's own SID whose message argument is
+ * "+<prefix>" followed by one placeholder per required argument. uhub
+ * intercepts a main-chat (BMSG) line starting with '+' or '!' as a command
+ * (see hub.c).
+ *
+ * The line passed to send_user_command() is the literal protocol line BEFORE
+ * the core escapes it into the TT field, so it must carry its own
+ * argument-internal escaping:
+ *   - the spaces separating BMSG / SID / the message argument are real ADC
+ *     separators and stay as plain spaces;
+ *   - a space *inside* the message argument is "\s" (written "\\s" here);
+ *   - the trailing "\n" terminates the line the client sends.
+ *
+ * Client-side substitutions (filled in by the client before sending):
+ *   %[mySID]           -> the clicking user's own SID
+ *   %[userNI]          -> the targeted user's nick   (CT_USER entries)
+ *   %[userCID]         -> the targeted user's CID    (CT_USER entries)
+ *   %[line:Prompt]     -> prompt the user for a line of free text
+ */
+
+static void emit_command(struct plugin_handle* plugin, const struct plugin_command_info* cmd, void* ptr)
+{
+	struct plugin_user* user = (struct plugin_user*) ptr;
+	char name[256];
+	char line[512];
+	int context = UCMD_CT_HUB;
+	size_t len;
+	size_t i;
+
+	/* Group every command under a top-level "uhub" submenu, using the
+	 * human-readable description (falling back to the prefix) as the leaf. */
+	snprintf(name, sizeof(name), "uhub/%s", (cmd->description && *cmd->description) ? cmd->description : cmd->prefix);
+
+	len = (size_t) snprintf(line, sizeof(line), "BMSG %%[mySID] +%s", cmd->prefix);
+	if (len >= sizeof(line))
+		return;
+
+	for (i = 0; cmd->args && cmd->args[i]; i++)
+	{
+		const char* placeholder;
+		char code = cmd->args[i];
+
+		if (code == '?')
+			break;      /* optional argument: leave it and any following out */
+		if (code == '+')
+			continue;   /* greedy modifier: applies to the next (string) code */
+
+		switch (code)
+		{
+			case 'u': /* fall through */
+			case 'n': placeholder = "%[userNI]";  context = UCMD_CT_USER; break;
+			case 'i': placeholder = "%[userCID]"; context = UCMD_CT_USER; break;
+			case 'm': placeholder = "%[line:Message]";       break;
+			case 'N': placeholder = "%[line:Number]";        break;
+			case 'a': placeholder = "%[line:Address]";       break;
+			case 'r': placeholder = "%[line:Address range]"; break;
+			case 'p': placeholder = "%[line:Password]";      break;
+			case 'C': placeholder = "%[line:Credentials]";   break;
+			case 'c': placeholder = "%[line:Command]";       break;
+			default:  placeholder = "%[line:Argument]";      break;
+		}
+
+		len += (size_t) snprintf(line + len, sizeof(line) - len, "\\s%s", placeholder);
+		if (len >= sizeof(line))
+			return;
+	}
+
+	/* Terminate the line the client will transmit. */
+	if (len + 2 > sizeof(line))
+		return;
+	line[len++] = '\n';
+	line[len] = '\0';
+
+	plugin->hub.send_user_command(plugin, user, name, context, line);
+}
+
+static void on_user_login(struct plugin_handle* plugin, struct plugin_user* user)
+{
+	/* Enumerate every command available at this user's credential level and
+	 * publish each as a UCMD entry. Clients that did not advertise UCM0 ignore
+	 * the unknown ICMD messages, so sending unconditionally is safe. The
+	 * plugin API does not expose per-user feature flags, so no gate on
+	 * feature_ucmd is applied. */
+	plugin->hub.command_foreach(plugin, user->credentials, emit_command, user);
+}
+
+int plugin_register(struct plugin_handle* plugin, const char* config)
+{
+	PLUGIN_INITIALIZE(plugin, "UCMD plugin", "0.2",
+		"Publishes registered hub commands as ADC user-command (UCMD) context menus.");
+	plugin->funcs.on_user_login = on_user_login;
+	return 0;
+}
+
+int plugin_unregister(struct plugin_handle* plugin)
+{
+	/* The ICMD entries live in each client; there is nothing hub-side to free.
+	 * To clear a client's menu you would re-send each entry with an "RM" field. */
+	return 0;
+}


### PR DESCRIPTION
Automatically create UCMD/UCM0 for all hub commands.