### PR TITLE
Test hardening & related bug fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,9 @@ jobs:
       - name: Run adcrush churn under ASan
         run: BUILD=build-stress test/e2e/run_adcrush_asan.sh
 
+      - name: Run federation (linked-hub) churn under ASan
+        run: BUILD=build-stress test/e2e/run_link_stress_asan.sh
+
   # ---------------------------------------------------------------------------
   # Time-boxed regression fuzzing of the pre-auth ADC parser. Seeded from the
   # checked-in corpus + dictionary. A crash fails the job and uploads the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,7 +441,12 @@ jobs:
       - name: Generate coverage report
         run: |
           mkdir -p coverage-html
+          # gcov can emit a bogus negative branch count ("branch N taken -3",
+          # GCC bug 68080); gcovr treats that as a fatal parse error by default.
+          # Downgrade it to a per-file warning so a gcov quirk does not fail the
+          # (best-effort, informational) coverage job.
           gcovr --root . --filter 'src/' \
+            --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
             --print-summary \
             --xml coverage.xml \
             --html-details coverage-html/index.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,37 @@ jobs:
         run: EVENT_NOKQUEUE=1 ./build-asan/autotest-bin
 
   # ---------------------------------------------------------------------------
+  # Connection-churn stress under ASan/UBSan: run the adcrush load generator
+  # against a live hub, then shut the hub down with clients still attached. This
+  # drives the accept/login/route/teardown lifecycle under load -- churn the unit
+  # suite never produces -- and guards the shutdown-time user-manager UAF.
+  # ---------------------------------------------------------------------------
+  stress:
+    name: adcrush churn (asan)
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y cmake perl libsqlite3-dev libssl-dev clang
+
+      - name: Configure (ASan/UBSan + stress tools)
+        run: |
+          cmake -S . -B build-stress -DRELEASE=OFF -DADC_STRESS=ON \
+            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -g -O1 -fno-omit-frame-pointer" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+
+      - name: Build hub + adcrush
+        run: cmake --build build-stress --target uhub adcrush -j
+
+      - name: Run adcrush churn under ASan
+        run: BUILD=build-stress test/e2e/run_adcrush_asan.sh
+
+  # ---------------------------------------------------------------------------
   # Time-boxed regression fuzzing of the pre-auth ADC parser. Seeded from the
   # checked-in corpus + dictionary. A crash fails the job and uploads the
   # reproducer as an artifact.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,12 +426,17 @@ jobs:
 
       - name: Configure (coverage)
         run: |
-          cmake -S . -B build-cov -DRELEASE=OFF \
+          cmake -S . -B build-cov -DRELEASE=OFF -DADC_STRESS=ON \
             -DCMAKE_C_FLAGS="--coverage -O0 -g" \
             -DCMAKE_EXE_LINKER_FLAGS="--coverage"
 
+      # Also build the real hub, the load/scripted clients and the plugins the
+      # runtime scenarios drive, so their .gcda contributes to the report.
       - name: Build
-        run: cmake --build build-cov --target autotest-bin -j
+        run: |
+          cmake --build build-cov -j --target \
+            autotest-bin uhub uhub-passwd adc_cmd adcrush \
+            mod_auth_sqlite mod_e2e_test
 
       # Two runs so both event backends are covered: the default (epoll) and,
       # forced via EVENT_NOEPOLL, the select fallback. .gcda counters accumulate
@@ -441,6 +446,19 @@ jobs:
           ./build-cov/autotest-bin
           EVENT_NOEPOLL=1 ./build-cov/autotest-bin
 
+      # Drive the instrumented hub through real client / linked-hub scenarios so
+      # the accept, login-pipeline, routing, plugin-dispatch, federation and
+      # clean-shutdown paths -- which the unit suite barely reaches -- are
+      # counted. gcov flushes .gcda when the hub exits on SIGTERM. These are
+      # best-effort for the report; the sanitizer/stress jobs are the crash gate.
+      - name: Run runtime scenarios (real clients + links)
+        run: |
+          for s in run_adcrush_asan run_link_stress_asan \
+                   run_plugin_e2e run_ban_e2e run_link_e2e; do
+            echo "== $s =="
+            BUILD=build-cov bash "test/e2e/$s.sh" || echo "($s did not pass; coverage still counted)"
+          done
+
       - name: Generate coverage report
         run: |
           mkdir -p coverage-html
@@ -448,7 +466,9 @@ jobs:
           # GCC bug 68080); gcovr treats that as a fatal parse error by default.
           # Downgrade it to a per-file warning so a gcov quirk does not fail the
           # (best-effort, informational) coverage job.
-          gcovr --root . --filter 'src/' \
+          # Exclude the test-only tooling (load/scripted clients) so the metric
+          # reflects the hub/library product code, not the harness.
+          gcovr --root . --filter 'src/' --exclude 'src/tools/' \
             --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
             --print-summary \
             --xml coverage.xml \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,31 @@ jobs:
           prepare: |
             pkg install -y cmake perl5 sqlite3
           run: |
+            set -e
+            # Capture a core if autotest crashes (an intermittent kqueue/DNS
+            # segfault has been seen here). Cores land as <name>.core in the cwd
+            # (kern.corefile default), which the action syncs back to the host
+            # for the upload step below.
+            ulimit -c unlimited
             cmake -S . -B build -DRELEASE=OFF
             # FreeBSD's make (bmake) requires an argument for -j, unlike the GNU
             # make used on the Linux/macOS jobs where a bare -j is fine.
             cmake --build build -j $(sysctl -n hw.ncpu)
             ./build/autotest-bin
             EVENT_NOKQUEUE=1 ./build/autotest-bin
+
+      # If the VM run failed (e.g. the intermittent crash), keep any core dump
+      # and the unstripped binary so the failure can be debugged offline.
+      - name: Upload crash core dump
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: freebsd-cores
+          path: |
+            *.core
+            **/*.core
+            build/autotest-bin
+          if-no-files-found: ignore
 
   # ---------------------------------------------------------------------------
   # Windows build on a native runner. uhub's Windows support is the build.zig
@@ -187,6 +206,76 @@ jobs:
           ASAN_OPTIONS: detect_leaks=1:abort_on_error=1
           UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
         run: ./build-asan/autotest-bin
+
+  # ---------------------------------------------------------------------------
+  # ThreadSanitizer over the full suite. The hub is single-threaded except for
+  # the DNS resolver worker pool, so this is the one place a data race can live;
+  # the DNS pool stress tests (test_connect.tcc) drive it under contention.
+  # ---------------------------------------------------------------------------
+  tsan:
+    name: threadsanitizer
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y cmake perl libsqlite3-dev libssl-dev clang
+
+      - name: Configure (TSan)
+        run: |
+          cmake -S . -B build-tsan -DRELEASE=OFF \
+            -DCMAKE_C_FLAGS="-fsanitize=thread -g -O1 -fno-omit-frame-pointer" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"
+
+      - name: Build
+        run: cmake --build build-tsan --target autotest-bin -j
+
+      - name: Run unit tests under TSan
+        env:
+          TSAN_OPTIONS: halt_on_error=1
+        run: ./build-tsan/autotest-bin
+
+  # ---------------------------------------------------------------------------
+  # AddressSanitizer + UndefinedBehaviorSanitizer on macOS, so the kqueue
+  # backend and the DNS pool are exercised under a sanitizer (the Linux asan job
+  # runs the epoll backend; kqueue was previously never sanitized). LSan is not
+  # available on macOS, so leak detection is left off.
+  # ---------------------------------------------------------------------------
+  macos-asan:
+    name: macos asan+ubsan (kqueue)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install dependencies
+        run: brew install cmake sqlite openssl@3
+
+      - name: Configure (ASan/UBSan)
+        run: |
+          cmake -S . -B build-asan -DRELEASE=OFF \
+            -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" \
+            -DCMAKE_PREFIX_PATH="$(brew --prefix sqlite)" \
+            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -g -O1 -fno-omit-frame-pointer" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+
+      - name: Build
+        run: cmake --build build-asan --target autotest-bin -j
+
+      - name: Run unit tests under ASan/UBSan (kqueue)
+        env:
+          ASAN_OPTIONS: abort_on_error=1
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: ./build-asan/autotest-bin
+
+      - name: Run unit tests under ASan/UBSan (select fallback)
+        env:
+          ASAN_OPTIONS: abort_on_error=1
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: EVENT_NOKQUEUE=1 ./build-asan/autotest-bin
 
   # ---------------------------------------------------------------------------
   # Time-boxed regression fuzzing of the pre-auth ADC parser. Seeded from the

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/janvidar/uhub/actions/workflows/ci.yml/badge.svg)](https://github.com/janvidar/uhub/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/janvidar/uhub/actions/workflows/codeql.yml/badge.svg)](https://github.com/janvidar/uhub/actions/workflows/codeql.yml)
+[![codecov](https://codecov.io/gh/janvidar/uhub/graph/badge.svg)](https://codecov.io/gh/janvidar/uhub)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](COPYING)
 
 **uhub** is a small, fast, and secure peer-to-peer hub server for the

--- a/autotest/test_connect.tcc
+++ b/autotest/test_connect.tcc
@@ -1,6 +1,7 @@
 #include "network/network.h"
 #include "network/connection.h"
 #include "network/backend.h"
+#include "network/dnsresolver.h"
 
 /*
  * Tests for the outbound-connect / happy-eyeballs failover path in
@@ -189,6 +190,42 @@ EXO_TEST(connect_failover_localhost, {
 	return ct_state.calls == 1
 		&& ct_state.status != net_connect_status_ok
 		&& ct_state.con == 0;
+});
+
+/*
+ * Regression: a DNS callback that takes ownership of the result (returns 0)
+ * and frees it synchronously must not lead net_dns_process to touch the freed
+ * result/job afterwards. This mirrors net_con_connect_dns_callback, which frees
+ * handle->result (via net_connect_destroy) on its synchronous-completion paths
+ * -- "no usable addresses" and "every connect failed synchronously" -- and then
+ * returns 0. Previously net_dns_process would still run
+ * "result->job = NULL; free_job(job);", a use-after-free write plus a double
+ * free of the job -- heap corruption that showed up as an intermittent,
+ * platform-dependent crash. Deterministic here: a numeric-literal host resolves
+ * offline, and the callback frees the delivered result and returns 0.
+ * Under ASan this aborts before the fix and passes after it.
+ */
+static int dns_owner_fired = 0;
+static int dns_owner_free_callback(struct net_dns_job* job, const struct net_dns_result* result)
+{
+	(void) job;
+	dns_owner_fired = 1;
+	if (result)
+		net_dns_result_free(result);   /* take ownership and free it now */
+	return 0;                          /* 0 == "caller owns the result" */
+}
+
+EXO_TEST(connect_dns_owner_frees_sync, {
+	int i;
+	struct net_dns_job* job;
+	dns_owner_fired = 0;
+	/* A numeric literal resolves offline (getaddrinfo, no DNS query). */
+	job = net_dns_gethostbyname("127.0.0.1", AF_UNSPEC, dns_owner_free_callback, 0);
+	if (!job)
+		return 0;
+	for (i = 0; i < 10000 && !dns_owner_fired; i++)
+		net_backend_process();
+	return dns_owner_fired == 1;
 });
 
 EXO_TEST(connect_shutdown, {

--- a/autotest/test_connect.tcc
+++ b/autotest/test_connect.tcc
@@ -228,6 +228,69 @@ EXO_TEST(connect_dns_owner_frees_sync, {
 	return dns_owner_fired == 1;
 });
 
+/*
+ * Concurrency stress for the DNS worker pool. The rest of the suite only ever
+ * has one lookup in flight at a time; here many are queued before the loop is
+ * pumped, so up to pool-size worker threads race on the shared queue/results
+ * list, the mutex/condvars, and the notify-pipe handoff back to the event
+ * thread. Numeric-literal hosts resolve offline (getaddrinfo, no DNS traffic),
+ * keeping it fast and deterministic. Run under ASan (and TSan, once wired) this
+ * exercises the threaded paths that a single serial lookup never reaches.
+ */
+static int dns_stress_count = 0;
+static int dns_stress_cb(struct net_dns_job* job, const struct net_dns_result* result)
+{
+	(void) job; (void) result;   /* delivered on the event thread; single-threaded here */
+	dns_stress_count++;
+	return 1;                    /* decline ownership: net_dns_process frees the result */
+}
+
+EXO_TEST(connect_dns_pool_concurrent, {
+	int i;
+	int pumps;
+	const int N = 64;
+	dns_stress_count = 0;
+	/* Queue every lookup first so the workers have a backlog to contend over. */
+	for (i = 0; i < N; i++)
+	{
+		const char* host = (i & 1) ? "127.0.0.1" : "::1";
+		if (!net_dns_gethostbyname(host, AF_UNSPEC, dns_stress_cb, 0))
+			return 0;
+	}
+	for (pumps = 0; pumps < 100000 && dns_stress_count < N; pumps++)
+		net_backend_process();
+	return dns_stress_count == N;
+});
+
+/*
+ * Cancel a job in each pre-delivery state. Cancelling before any pump means the
+ * targets are QUEUED, RUNNING, or DONE-but-undelivered -- every branch of
+ * net_dns_job_cancel -- and a cancelled job must never invoke its callback.
+ */
+EXO_TEST(connect_dns_cancel_races, {
+	int i;
+	int pumps;
+	const int N = 16;
+	struct net_dns_job* jobs[16];
+	dns_stress_count = 0;
+	for (i = 0; i < N; i++)
+	{
+		jobs[i] = net_dns_gethostbyname("127.0.0.1", AF_UNSPEC, dns_stress_cb, 0);
+		if (!jobs[i])
+			return 0;
+	}
+	/* Cancel the even-indexed jobs (no pump yet, so none have delivered). */
+	for (i = 0; i < N; i += 2)
+		net_dns_job_cancel(jobs[i]);
+	/* Only the odd (non-cancelled) half may call back. */
+	for (pumps = 0; pumps < 100000 && dns_stress_count < N / 2; pumps++)
+		net_backend_process();
+	/* A few more pumps: a cancelled job must not sneak in a late callback. */
+	for (pumps = 0; pumps < 50; pumps++)
+		net_backend_process();
+	return dns_stress_count == N / 2;
+});
+
 EXO_TEST(connect_shutdown, {
 	return net_destroy() == 0;
 });

--- a/autotest/test_netbackend.tcc
+++ b/autotest/test_netbackend.tcc
@@ -120,6 +120,48 @@ EXO_TEST(netbackend_update_disables_write, {
 	return (nb_state.events & NET_EVENT_READ) && !(nb_state.events & NET_EVENT_WRITE);
 });
 
+/*
+ * Exercise the close / backend-deregister path (con_del, and on kqueue the
+ * deferred change_list DEL processed by create_change_list) that the cases
+ * above deliberately avoid. Register a second connection, flush its add, close
+ * it, then pump once more so the backend actually processes the queued
+ * deregistration. nb_con is kept readable so the poll returns promptly instead
+ * of blocking on the idle timeout. This covers the previously-untested del path
+ * that the kqueue create_change_list bounds fix hardens.
+ */
+EXO_TEST(netbackend_close_deregister, {
+	int sv2[2];
+	int i;
+	struct net_connection* c2;
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv2) != 0)
+		return 0;
+	c2 = net_con_create();
+	net_con_initialize(c2, sv2[0], nb_callback, &nb_state, NET_EVENT_READ);
+
+	/* Flush c2's registration; keep nb_con readable so the poll returns. */
+	nb_reset(&nb_state);
+	if (write(nb_sv[1], "a", 1) != 1)
+		return 0;
+	net_backend_process();
+
+	/* Close c2: deregisters the fd now, queues the backend DEL for next poll. */
+	net_con_close(c2);
+	close(sv2[1]);
+
+	/* Pump so create_change_list (kqueue) processes c2's DEL entry; a bad
+	   deregister index would fault here under ASan. The DEL is flushed on the
+	   first poll after close; keep nb_con readable and pump until it delivers,
+	   recovering from the single-cycle kevent perturbation the DEL can cause. */
+	nb_reset(&nb_state);
+	if (write(nb_sv[1], "b", 1) != 1)
+		return 0;
+	for (i = 0; i < 100 && nb_state.reads == 0; i++)
+		net_backend_process();
+
+	/* Backend survived the deregister and still delivers to the live connection. */
+	return nb_state.reads >= 1;
+});
+
 EXO_TEST(netbackend_teardown, {
 	/* net_con_close() synchronously deregisters the fd; the struct free is
 	   deferred and flushed by net_destroy() at shutdown. No poll here: with

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -51,15 +51,16 @@ static int config_check_regexp(const char* key, const char* data, const char* re
 {
 	regex_t preg;
 	char* pattern;
+	size_t pattern_sz = strlen(regexp) + 5; /* "^(" + regexp + ")$" + NUL */
 	int rc;
 
-	pattern = hub_malloc(strlen(regexp) + 5); /* "^(" + regexp + ")$" + NUL */
+	pattern = hub_malloc(pattern_sz);
 	if (!pattern)
 	{
 		LOG_ERROR("Out of memory validating config key '%s'", key);
 		return 0;
 	}
-	sprintf(pattern, "^(%s)$", regexp);
+	snprintf(pattern, pattern_sz, "^(%s)$", regexp);
 
 	rc = regcomp(&preg, pattern, REG_EXTENDED | REG_NOSUB);
 	hub_free(pattern);

--- a/src/core/hub.c
+++ b/src/core/hub.c
@@ -1771,6 +1771,7 @@ void hub_disconnect_user(struct hub_info* hub, struct hub_user* user, int reason
 {
 	struct event_data post;
 	int need_notify = 0;
+	int was_logged_in;
 
 	/* is user already being disconnected ? */
 	if (user_is_disconnecting(user))
@@ -1796,7 +1797,10 @@ void hub_disconnect_user(struct hub_info* hub, struct hub_user* user, int reason
 
 	LOG_TRACE("hub_disconnect_user(), user=%p, reason=%d, state=%d", user, reason, user->state);
 
-	need_notify = user_is_logged_in(user) && hub->status == hub_status_running;
+	/* Capture "logged in" (i.e. present in the user manager) before the cleanup
+	   state transition below flips it. */
+	was_logged_in = user_is_logged_in(user);
+	need_notify = was_logged_in && hub->status == hub_status_running;
 	user->quit_reason = reason;
 	user_set_state(user, state_cleanup);
 
@@ -1809,6 +1813,15 @@ void hub_disconnect_user(struct hub_info* hub, struct hub_user* user, int reason
 	}
 	else
 	{
+		/* This path does not go through UHUB_EVENT_USER_QUIT, which is what
+		   unlinks a user from the user manager. A logged-in user reaches here
+		   only when the hub is not running (e.g. shutting down); if left linked
+		   it would be freed by UHUB_EVENT_USER_DESTROY yet still sit in the user
+		   list, and the UHUB_EVENT_HUB_SHUTDOWN sweep -- which calls uman_remove
+		   on every listed user -- would then touch freed memory. Unlink it here
+		   so destroy operates on an already-removed user. */
+		if (was_logged_in)
+			uman_remove(hub->users, user);
 		hub_schedule_destroy_user(hub, user);
 	}
 }

--- a/src/network/dnsresolver.c
+++ b/src/network/dnsresolver.c
@@ -253,17 +253,16 @@ void net_dns_process()
 		DNS_LOG_LOOKUP_TIME(job);
 		if (job->callback(job, delivered))
 		{
+			/* Callback declined ownership: we release the result (and, via
+			 * net_dns_result_free, the job it carries). */
 			net_dns_result_free(result);
 		}
-		else
-		{
-			/* Caller wants to keep the result data, and
-			 * thus needs to call net_dns_result_free() to release it later.
-			 * We only clean up the job data here and keep the results intact.
-			 */
-			result->job = NULL;
-			free_job(job);
-		}
+		/* else: the callback took ownership of the result -- and the job it
+		 * carries -- and will release both with net_dns_result_free() later.
+		 * We must NOT touch result or job here: a callback is allowed to free
+		 * the result synchronously (e.g. net_con_connect_dns_callback frees it
+		 * via net_connect_destroy when a connect completes/fails synchronously),
+		 * so any access after the call would be a use-after-free / double-free. */
 	});
 
 	list_clear(ready, NULL); // free the nodes only; results were freed above

--- a/src/network/kqueue.c
+++ b/src/network/kqueue.c
@@ -269,6 +269,14 @@ static size_t create_change_list(struct net_backend_kqueue* backend)
 	for (; n < backend->change_list_len; n++)
 	{
 		sd = backend->change_list[n];
+		/* add_change() queues con->sd unconditionally, including for a del of an
+		   fd that add rejected (>= max) or a connection closed before it was
+		   given a descriptor (sd == -1). Guard the array index here -- the single
+		   point that consumes the queued descriptor -- so such an entry cannot
+		   index conns[] out of bounds (conns[-1] / past the end). Nothing was ever
+		   registered for it, so there is no kqueue filter to remove either. */
+		if (sd < 0 || (size_t) sd >= backend->common->max)
+			continue;
 		con = backend->conns[sd];
 		if (con)
 		{

--- a/test/e2e/run_adcrush_asan.sh
+++ b/test/e2e/run_adcrush_asan.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Connection-churn stress: hammer a hub with adcrush (many bots connecting,
+# logging in and disconnecting), then shut the hub down while clients are still
+# attached. Built under a sanitizer, this exercises the accept / login / route /
+# teardown lifecycle under load -- the churn the unit suite never produces.
+#
+# It is the regression guard for the shutdown-time user-manager use-after-free
+# (a user disconnected while the hub was not running was freed while still
+# linked, and the HUB_SHUTDOWN sweep then called uman_remove on freed memory).
+# adcrush is a single-threaded load generator against the single-threaded hub;
+# this is lifecycle/memory coverage, not a data-race test.
+#
+# Usage:  BUILD=/path/to/build  test/e2e/run_adcrush_asan.sh  [port]
+# The build must have -DADC_STRESS=ON and a sanitizer enabled.
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../.." && pwd)
+BUILD=${BUILD:-$REPO/build}
+PORT=${1:-52123}
+
+UHUB=$BUILD/uhub
+CRUSH=$BUILD/adcrush
+for f in "$UHUB" "$CRUSH"; do
+	[ -x "$f" ] || { echo "MISSING: $f (build with -DADC_STRESS=ON)"; exit 2; }
+done
+
+DIR=$(mktemp -d)
+HUB_PID=""
+cleanup() { [ -n "$HUB_PID" ] && kill "$HUB_PID" 2>/dev/null; wait 2>/dev/null; rm -rf "$DIR"; }
+trap cleanup EXIT
+
+cat > "$DIR/uhub.conf" <<EOF
+server_port = $PORT
+server_bind_addr = 127.0.0.1
+tls_enable = 0
+EOF
+
+# abort_on_error so a sanitizer report is a hard failure; no LSan on macOS.
+export ASAN_OPTIONS="detect_leaks=0:abort_on_error=1"
+export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1"
+
+"$UHUB" -c "$DIR/uhub.conf" > "$DIR/hub.log" 2>&1 &
+HUB_PID=$!
+
+listening=0
+for _ in $(seq 1 100); do
+	if (exec 3<>"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then exec 3>&- 3<&-; listening=1; break; fi
+	kill -0 "$HUB_PID" 2>/dev/null || break
+	sleep 0.1
+done
+[ "$listening" = 1 ] || { echo "FAIL: hub did not start"; cat "$DIR/hub.log"; exit 1; }
+
+# Storm: 50 aggressive bots for a few seconds, then stop the client.
+"$CRUSH" "adc://127.0.0.1:$PORT" -n 50 -l 3 -q > "$DIR/adcrush.log" 2>&1 &
+CRUSH_PID=$!
+sleep 8
+kill "$CRUSH_PID" 2>/dev/null; wait "$CRUSH_PID" 2>/dev/null
+
+# A crash during the storm would have taken the hub down already.
+if ! kill -0 "$HUB_PID" 2>/dev/null; then
+	echo "FAIL: hub died during the storm"; cat "$DIR/hub.log"; HUB_PID=""; exit 1
+fi
+
+# Graceful shutdown while bots may still be attached: drives the teardown sweep.
+kill -TERM "$HUB_PID"; wait "$HUB_PID"; rc=$?
+HUB_PID=""
+
+if grep -q "Sanitizer" "$DIR/hub.log"; then
+	echo "FAIL: sanitizer error in the hub:"; cat "$DIR/hub.log"; exit 1
+fi
+if [ "$rc" -ne 0 ]; then
+	echo "FAIL: hub exited non-zero ($rc)"; cat "$DIR/hub.log"; exit 1
+fi
+echo "PASS: adcrush storm + shutdown stayed sanitizer-clean"

--- a/test/e2e/run_link_stress_asan.sh
+++ b/test/e2e/run_link_stress_asan.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Federation churn stress: link two hubs, storm BOTH with adcrush so local user
+# joins/quits propagate across the link, then shut both down while users (local
+# and remote) are still attached. Built under a sanitizer, this exercises the
+# federation code path -- remote-user create/destroy (user_create_remote /
+# uman_add_remote / uman_remove_remote), roster propagation, and link teardown
+# under load -- which the single-hub adcrush churn never touches.
+#
+# It complements run_adcrush_asan.sh (single hub). Like that one, this is
+# lifecycle/memory coverage under load, not a data-race test.
+#
+# Usage:  BUILD=/path/to/build  test/e2e/run_link_stress_asan.sh  [portA] [portB]
+# The build must have -DADC_STRESS=ON and a sanitizer enabled.
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../.." && pwd)
+BUILD=${BUILD:-$REPO/build}
+PA=${1:-52141}
+PB=${2:-52142}
+SECRET="link-stress-secret"
+
+UHUB=$BUILD/uhub
+CRUSH=$BUILD/adcrush
+for f in "$UHUB" "$CRUSH"; do
+	[ -x "$f" ] || { echo "MISSING: $f (build with -DADC_STRESS=ON)"; exit 2; }
+done
+
+DIR=$(mktemp -d)
+PIDS=()
+cleanup() { for p in "${PIDS[@]:-}"; do [ -n "$p" ] && kill "$p" 2>/dev/null; done; wait 2>/dev/null; rm -rf "$DIR"; }
+trap cleanup EXIT
+
+export ASAN_OPTIONS="detect_leaks=0:abort_on_error=1"
+export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1"
+
+cat > "$DIR/hub_a.conf" <<EOF
+server_port = $PA
+server_bind_addr = 127.0.0.1
+tls_enable = 0
+link_secret = $SECRET
+node_count = 2
+node_id = 0
+EOF
+cat > "$DIR/hub_b.conf" <<EOF
+server_port = $PB
+server_bind_addr = 127.0.0.1
+tls_enable = 0
+link_secret = $SECRET
+node_count = 2
+node_id = 1
+link_peer = 127.0.0.1:$PA
+EOF
+
+start_hub() { # conf log port -> sets HUB_PID
+	"$UHUB" -c "$1" -v -v > "$2" 2>&1 &
+	HUB_PID=$!
+	PIDS+=("$HUB_PID")
+	local i
+	for i in $(seq 1 100); do
+		(exec 3<>"/dev/tcp/127.0.0.1/$3") 2>/dev/null && { exec 3>&- 3<&-; return 0; }
+		kill -0 "$HUB_PID" 2>/dev/null || { echo "hub died:"; cat "$2"; return 1; }
+		sleep 0.1
+	done
+	echo "hub not listening on $3:"; cat "$2"; return 1
+}
+
+wait_for() { # pattern file [tries]
+	local pat=$1 file=$2 n=${3:-100} i
+	for i in $(seq 1 "$n"); do grep -q "$pat" "$file" 2>/dev/null && return 0; sleep 0.1; done
+	return 1
+}
+
+start_hub "$DIR/hub_a.conf" "$DIR/hubA.log" "$PA" || exit 1
+HUBA_PID=$HUB_PID
+start_hub "$DIR/hub_b.conf" "$DIR/hubB.log" "$PB" || exit 1
+HUBB_PID=$HUB_PID
+
+if ! { wait_for "link established" "$DIR/hubA.log" && wait_for "link established" "$DIR/hubB.log"; }; then
+	echo "FAIL: link not established"; cat "$DIR/hubA.log" "$DIR/hubB.log"; exit 1
+fi
+
+# Storm both hubs so joins/quits propagate across the link in both directions.
+"$CRUSH" "adc://127.0.0.1:$PA" -n 40 -l 3 -q > "$DIR/crushA.log" 2>&1 &
+PIDS+=("$!"); CA=$!
+"$CRUSH" "adc://127.0.0.1:$PB" -n 40 -l 3 -q > "$DIR/crushB.log" 2>&1 &
+PIDS+=("$!"); CB=$!
+sleep 10
+kill "$CA" "$CB" 2>/dev/null; wait "$CA" "$CB" 2>/dev/null
+
+for pair in "A:$HUBA_PID:$DIR/hubA.log" "B:$HUBB_PID:$DIR/hubB.log"; do
+	name=${pair%%:*}; rest=${pair#*:}; pid=${rest%%:*}; log=${rest#*:}
+	if ! kill -0 "$pid" 2>/dev/null; then
+		echo "FAIL: hub $name died during the storm"; cat "$log"; exit 1
+	fi
+done
+
+# Shut both down with local + remote users still attached (link teardown).
+kill -TERM "$HUBA_PID" "$HUBB_PID"
+wait "$HUBA_PID"; rcA=$?
+wait "$HUBB_PID"; rcB=$?
+
+for pair in "A:$rcA:$DIR/hubA.log" "B:$rcB:$DIR/hubB.log"; do
+	name=${pair%%:*}; rest=${pair#*:}; rc=${rest%%:*}; log=${rest#*:}
+	if grep -q "Sanitizer" "$log"; then
+		echo "FAIL: sanitizer error in hub $name:"; cat "$log"; exit 1
+	fi
+	if [ "$rc" -ne 0 ]; then
+		echo "FAIL: hub $name exited non-zero ($rc)"; cat "$log"; exit 1
+	fi
+done
+echo "PASS: linked-hub federation churn + shutdown stayed sanitizer-clean"


### PR DESCRIPTION
Summary

Harden the network / event-loop / DNS layer and widen the sanitizer + stress coverage around it. Prompted by an intermittent, FreeBSD-only segfault in the test suite; the investigation turned up two confirmed use-after-frees (and a latent OOB) that the existing tests never reached, plus large gaps in how those paths are tested.

Bugs fixed

- DNS result-delivery UAF / double-free (net_dns_process): after a callback returned 0 ("I own the result"), the resolver still `ran result->job = NULL; free_job(job)` — but a callback can free the result synchronously first (net_con_connect_dns_callback via net_connect_destroy on its "no usable addresses" / all-connects-failed-synchronously paths). Timing/heap-dependent → matches the intermittent, platform-varying crash (BSD refuses loopback connects synchronously; Linux/macOS go async). Fix: on return 0 the callback owns the result+job; net_dns_process must not touch them.
- Shutdown-time user-manager UAF (hub_disconnect_user): a logged-in user disconnected while the hub isn't running was freed via USER_DESTROY without uman_remove, then the HUB_SHUTDOWN sweep uman_remove'd the freed user. Fix: unlink still-logged-in users on that path too. Found by the new adcrush churn job under ASan; reproduces on macOS.
- kqueue change_list OOB read: a del for an out-of-range/-1 fd got queued and later indexed conns[sd] unguarded (kqueue only; epoll/select guard first). Guarded at the consuming site.

Tests added

Deterministic DNS-UAF regression; DNS worker-pool concurrency stress (64 overlapping lookups + cancel-in-every-state); backend close/deregister coverage; test/e2e/run_adcrush_asan.sh churn harness.

CI added

tsan (DNS pool under ThreadSanitizer); macos-asan (kqueue + DNS pool under ASan — kqueue was never sanitized); stress (adcrush churn under ASan — lifecycle coverage, not a race test); FreeBSD core-dump capture on failure.