### PR TITLE
fuse: mount an ADC hub as a filesystem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           sudo apt-get update -qq
           # SQLite3 and a TLS library are hard requirements of CMakeLists.txt:
           # TLS is mandatory, so find_package(OpenSSL REQUIRED) always runs.
-          sudo apt-get install -y cmake libsqlite3-dev libssl-dev ${{ matrix.compiler }}
+          sudo apt-get install -y cmake libsqlite3-dev libssl-dev libbz2-dev ${{ matrix.compiler }}
 
       - name: Configure
         run: |
@@ -197,7 +197,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y cmake libsqlite3-dev libssl-dev clang
+          sudo apt-get install -y cmake libsqlite3-dev libssl-dev libbz2-dev clang
 
       # Built with RELEASE=OFF so the DEBUG-only internal ADC_MSG_ASSERT
       # consistency checks run under the sanitizers as well.
@@ -234,7 +234,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y cmake libsqlite3-dev libssl-dev clang
+          sudo apt-get install -y cmake libsqlite3-dev libssl-dev libbz2-dev clang
 
       - name: Configure (TSan)
         run: |
@@ -309,7 +309,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y cmake libsqlite3-dev libssl-dev clang gdb
+          sudo apt-get install -y cmake libsqlite3-dev libssl-dev libbz2-dev clang gdb
 
       - name: Configure (ASan/UBSan + stress tools)
         run: |
@@ -351,7 +351,7 @@ jobs:
           sudo apt-get update -qq
           # libsqlite3-dev / libssl-dev: CMakeLists requires SQLite3 and a TLS
           # library to configure, even though the fuzz targets don't use them.
-          sudo apt-get install -y cmake clang libsqlite3-dev libssl-dev
+          sudo apt-get install -y cmake clang libsqlite3-dev libssl-dev libbz2-dev
 
       - name: Configure (libFuzzer)
         run: cmake -S . -B build-fuzz -DFUZZING=ON -DRELEASE=ON
@@ -450,7 +450,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y cmake libsqlite3-dev libssl-dev gcc gcovr
+          sudo apt-get install -y cmake libsqlite3-dev libssl-dev libbz2-dev gcc gcovr
 
       - name: Configure (coverage)
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
           sudo apt-get update -qq
           # CMake requires SQLite3 and a TLS library. Same set as the build
           # jobs in ci.yml.
-          sudo apt-get install -y cmake libsqlite3-dev libssl-dev
+          sudo apt-get install -y cmake libsqlite3-dev libssl-dev libbz2-dev
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y cmake libsqlite3-dev libssl-dev
+          sudo apt-get install -y cmake libsqlite3-dev libssl-dev libbz2-dev
 
       # The gate that would have caught the incomplete 0.8.0 assets: unpack the
       # tarball somewhere with no .git anywhere above it and build it cold, with

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,25 @@ file (GLOB seeder_SOURCES CONFIGURE_DEPENDS ${UHUB_SOURCE_DIR}/seeder/*.c)
 set (seeder_test_SOURCES ${seeder_SOURCES})
 list (REMOVE_ITEM seeder_test_SOURCES ${UHUB_SOURCE_DIR}/seeder/main.c)
 
+# libbz2, for uhub-fuse: a peer's share is browsed by reading its file list,
+# which every DC client publishes bzip2-compressed. It ships no .pc file, hence
+# find_library rather than pkg-config.
+#
+# Optional on purpose. fuse/filelist.c is compiled into autotest-bin so that its
+# parser -- which reads bytes a stranger sent and turns them into path
+# components -- is tested in every build, and that part needs no library at all.
+# Without libbz2 the decompressor is a stub, the handful of tests that need one
+# skip, and only uhub-fuse itself insists on it.
+find_path(BZIP2_INCLUDE_DIR bzlib.h)
+find_library(BZIP2_LIBRARY NAMES bz2 bzip2)
+if (BZIP2_INCLUDE_DIR AND BZIP2_LIBRARY)
+	set (HAVE_BZLIB ON)
+	message (STATUS "bzip2: ${BZIP2_LIBRARY}")
+else()
+	set (HAVE_BZLIB OFF)
+	message (STATUS "bzip2: not found (uhub-fuse needs it; the file list tests will skip)")
+endif()
+
 # The filesystem client. fs.c and main.c are the only files that include
 # <fuse.h>; everything else is ordinary C that autotest-bin compiles whether or
 # not libfuse3 is installed, which is what keeps the path, roster and rendering
@@ -387,15 +406,12 @@ target_sources(autotest-bin PRIVATE
 	${UHUB_SOURCE_DIR}/plugins/mod_auth_sqlite.c)
 target_include_directories(autotest-bin PRIVATE ${AUTOTEST_DIR})
 
-# fuse/filelist.c is in fuse_test_SOURCES and uses bzlib; the tests drive it
-# directly, so autotest-bin needs the library whether or not uhub-fuse is built.
-find_path(BZIP2_INCLUDE_DIR bzlib.h)
-find_library(BZIP2_LIBRARY NAMES bz2 bzip2)
-if (BZIP2_INCLUDE_DIR AND BZIP2_LIBRARY)
+# fuse/filelist.c is in fuse_test_SOURCES. Its parser needs no library; its
+# decompressor does, and stubs itself out without one.
+if (HAVE_BZLIB)
 	target_include_directories(autotest-bin PRIVATE ${BZIP2_INCLUDE_DIR})
 	target_link_libraries(autotest-bin PRIVATE ${BZIP2_LIBRARY})
-else()
-	message (FATAL_ERROR "The test suite needs libbz2 (install libbz2-dev).")
+	target_compile_definitions(autotest-bin PRIVATE HAVE_BZLIB)
 endif()
 # Absolute path to the autotest/ dir so tests can locate checked-in fixtures
 # (e.g. the TLS test certificate) regardless of the working directory.
@@ -534,9 +550,7 @@ if(UNIX)
 	# A user on a hub with a share, for uhub-fuse's browse tests: uhub-seeder
 	# serves content by hash and has no share to list, so it cannot stand in
 	# for a peer being browsed. Needs libbz2 for the file list it publishes.
-	find_path(BZIP2_INCLUDE_DIR bzlib.h)
-	find_library(BZIP2_LIBRARY NAMES bz2 bzip2)
-	if (BZIP2_INCLUDE_DIR AND BZIP2_LIBRARY)
+	if (HAVE_BZLIB)
 		add_executable(filelist_peer ${CMAKE_SOURCE_DIR}/test/e2e/filelist_peer.c ${adcclient_SOURCES})
 		target_include_directories(filelist_peer PRIVATE ${UHUB_SOURCE_DIR}/tools ${BZIP2_INCLUDE_DIR})
 		target_link_libraries(filelist_peer adc network utils ${BZIP2_LIBRARY} pthread)
@@ -562,15 +576,10 @@ if(UNIX)
 		pkg_check_modules(FUSE3 REQUIRED IMPORTED_TARGET fuse3)
 		message (STATUS "FUSE support: libfuse ${FUSE3_VERSION}")
 
-		# A peer's share is browsed by reading its file list, which every DC
-		# client publishes bzip2-compressed. libbz2 ships no .pc file, hence
-		# find_library rather than pkg-config.
-		find_path(BZIP2_INCLUDE_DIR bzlib.h)
-		find_library(BZIP2_LIBRARY NAMES bz2 bzip2)
-		if (NOT BZIP2_INCLUDE_DIR OR NOT BZIP2_LIBRARY)
-			message (FATAL_ERROR "FUSE_SUPPORT needs libbz2 (install libbz2-dev).")
+		if (NOT HAVE_BZLIB)
+			message (FATAL_ERROR "FUSE_SUPPORT needs libbz2 (install libbz2-dev): "
+				"a peer's share is browsed by reading its bzip2-compressed file list.")
 		endif()
-		message (STATUS "FUSE support: bzip2 ${BZIP2_LIBRARY}")
 		# The transfer half is uhub-seeder's, driven rather than reimplemented:
 		# the client-to-client protocol, the content cache and the grants that
 		# authorise a connection. Only those three, not the whole daemon --
@@ -582,6 +591,7 @@ if(UNIX)
 			${UHUB_SOURCE_DIR}/seeder/sniff.c)
 		add_executable(uhub-fuse ${fuse_SOURCES} ${fuse_seeder_SOURCES} ${adcclient_SOURCES})
 		target_include_directories(uhub-fuse PRIVATE ${BZIP2_INCLUDE_DIR})
+		target_compile_definitions(uhub-fuse PRIVATE HAVE_BZLIB)
 		target_link_libraries(uhub-fuse adc network utils PkgConfig::FUSE3 SQLite::SQLite3 ${BZIP2_LIBRARY} pthread)
 	endif()
 
@@ -711,13 +721,13 @@ if (FUZZING)
 	add_fuzzer(fuzz_bbs_post ${UHUB_SOURCE_DIR}/tools/fuzz_bbs_post.c
 		${UHUB_SOURCE_DIR}/seeder/post.c ${UHUB_SOURCE_DIR}/seeder/embed.c)
 	# uhub-fuse's file list parser: XML and bzip2 from another user, turned
-	# into names in a mounted filesystem. Needs libbz2 but nothing else.
-	find_path(BZIP2_INCLUDE_DIR bzlib.h)
-	find_library(BZIP2_LIBRARY NAMES bz2 bzip2)
-	if (BZIP2_INCLUDE_DIR AND BZIP2_LIBRARY)
+	# into names in a mounted filesystem. The harness compresses its input, so
+	# unlike the parser it does need the library.
+	if (HAVE_BZLIB)
 		add_fuzzer(fuzz_filelist ${UHUB_SOURCE_DIR}/tools/fuzz_filelist.c
 			${UHUB_SOURCE_DIR}/fuse/filelist.c)
 		target_include_directories(fuzz_filelist PRIVATE ${BZIP2_INCLUDE_DIR})
+		target_compile_definitions(fuzz_filelist PRIVATE HAVE_BZLIB)
 		target_link_libraries(fuzz_filelist ${BZIP2_LIBRARY})
 	else()
 		message (STATUS "fuzz_filelist skipped: libbz2 not found")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ option(RELEASE "Release build, debug build if disabled" ON)
 option(LOWLEVEL_DEBUG "Enable low level debug messages." OFF)
 option(SYSTEMD_SUPPORT "Enable systemd notify and journal logging" OFF)
 option(ADC_STRESS "Enable the stress tester client" OFF)
+option(FUSE_SUPPORT "Build uhub-fuse, the filesystem client (needs libfuse3)" OFF)
 option(FUZZING "Build libFuzzer fuzz targets (requires clang)" OFF)
 option(JAVASCRIPT_SUPPORT "Build the mod_javascript plugin (embeds QuickJS, a git submodule)" OFF)
 
@@ -279,6 +280,16 @@ file (GLOB seeder_SOURCES CONFIGURE_DEPENDS ${UHUB_SOURCE_DIR}/seeder/*.c)
 set (seeder_test_SOURCES ${seeder_SOURCES})
 list (REMOVE_ITEM seeder_test_SOURCES ${UHUB_SOURCE_DIR}/seeder/main.c)
 
+# The filesystem client. fs.c and main.c are the only files that include
+# <fuse.h>; everything else is ordinary C that autotest-bin compiles whether or
+# not libfuse3 is installed, which is what keeps the path, roster and rendering
+# logic under test on a machine that cannot mount anything.
+file (GLOB fuse_SOURCES CONFIGURE_DEPENDS ${UHUB_SOURCE_DIR}/fuse/*.c)
+set (fuse_test_SOURCES ${fuse_SOURCES})
+list (REMOVE_ITEM fuse_test_SOURCES
+	${UHUB_SOURCE_DIR}/fuse/main.c
+	${UHUB_SOURCE_DIR}/fuse/fs.c)
+
 file (GLOB adc_SOURCES     CONFIGURE_DEPENDS ${UHUB_SOURCE_DIR}/adc/*.c)
 file (GLOB network_SOURCES CONFIGURE_DEPENDS ${UHUB_SOURCE_DIR}/network/*.c)
 file (GLOB utils_SOURCES   CONFIGURE_DEPENDS ${UHUB_SOURCE_DIR}/util/*.c)
@@ -371,9 +382,21 @@ exotic_add_tests(autotest-bin
 target_sources(autotest-bin PRIVATE
 	${uhub_SOURCES}
 	${seeder_test_SOURCES}
+	${fuse_test_SOURCES}
 	${UHUB_SOURCE_DIR}/tools/adcclient.c
 	${UHUB_SOURCE_DIR}/plugins/mod_auth_sqlite.c)
 target_include_directories(autotest-bin PRIVATE ${AUTOTEST_DIR})
+
+# fuse/filelist.c is in fuse_test_SOURCES and uses bzlib; the tests drive it
+# directly, so autotest-bin needs the library whether or not uhub-fuse is built.
+find_path(BZIP2_INCLUDE_DIR bzlib.h)
+find_library(BZIP2_LIBRARY NAMES bz2 bzip2)
+if (BZIP2_INCLUDE_DIR AND BZIP2_LIBRARY)
+	target_include_directories(autotest-bin PRIVATE ${BZIP2_INCLUDE_DIR})
+	target_link_libraries(autotest-bin PRIVATE ${BZIP2_LIBRARY})
+else()
+	message (FATAL_ERROR "The test suite needs libbz2 (install libbz2-dev).")
+endif()
 # Absolute path to the autotest/ dir so tests can locate checked-in fixtures
 # (e.g. the TLS test certificate) regardless of the working directory.
 target_compile_definitions(autotest-bin PRIVATE UHUB_TEST_DIR="${AUTOTEST_DIR}")
@@ -500,6 +523,25 @@ if(UNIX)
 	add_executable(adc_cmd ${CMAKE_SOURCE_DIR}/test/e2e/adc_cmd.c)
 	target_include_directories(adc_cmd PRIVATE ${UHUB_SOURCE_DIR}/tools)
 	target_link_libraries(adc_cmd adcclient adc network utils pthread)
+	# Puts a file into a seed cache and prints its TTH, so an end-to-end script
+	# can set up content to be served without a real DC client to transfer it
+	# in first. Test-only, not installed.
+	add_executable(seed_put ${CMAKE_SOURCE_DIR}/test/e2e/seed_put.c
+		${UHUB_SOURCE_DIR}/seeder/cache.c
+		${UHUB_SOURCE_DIR}/seeder/sniff.c)
+	target_link_libraries(seed_put adc network utils SQLite::SQLite3 pthread)
+
+	# A user on a hub with a share, for uhub-fuse's browse tests: uhub-seeder
+	# serves content by hash and has no share to list, so it cannot stand in
+	# for a peer being browsed. Needs libbz2 for the file list it publishes.
+	find_path(BZIP2_INCLUDE_DIR bzlib.h)
+	find_library(BZIP2_LIBRARY NAMES bz2 bzip2)
+	if (BZIP2_INCLUDE_DIR AND BZIP2_LIBRARY)
+		add_executable(filelist_peer ${CMAKE_SOURCE_DIR}/test/e2e/filelist_peer.c ${adcclient_SOURCES})
+		target_include_directories(filelist_peer PRIVATE ${UHUB_SOURCE_DIR}/tools ${BZIP2_INCLUDE_DIR})
+		target_link_libraries(filelist_peer adc network utils ${BZIP2_LIBRARY} pthread)
+	endif()
+
 	# Test-only plugin exercising the validate/ban hooks (not installed).
 	add_library(mod_e2e_test MODULE ${CMAKE_SOURCE_DIR}/test/e2e/mod_e2e_test.c)
 	set_target_properties(mod_e2e_test PROPERTIES PREFIX "")
@@ -510,6 +552,37 @@ if(UNIX)
 	target_link_libraries(uhub-seeder pthread)
 	if (UHUB_TESTS)
 		target_link_libraries(autotest-bin PRIVATE pthread)
+	endif()
+
+	# uhub-fuse: the hub, mounted. An ordinary ADC client like uhub-seeder, so
+	# it links the same libraries plus libfuse3. Off by default: libfuse is a
+	# dependency the hub itself does not have, and the mount is Linux/macOS only.
+	if (FUSE_SUPPORT)
+		find_package(PkgConfig REQUIRED)
+		pkg_check_modules(FUSE3 REQUIRED IMPORTED_TARGET fuse3)
+		message (STATUS "FUSE support: libfuse ${FUSE3_VERSION}")
+
+		# A peer's share is browsed by reading its file list, which every DC
+		# client publishes bzip2-compressed. libbz2 ships no .pc file, hence
+		# find_library rather than pkg-config.
+		find_path(BZIP2_INCLUDE_DIR bzlib.h)
+		find_library(BZIP2_LIBRARY NAMES bz2 bzip2)
+		if (NOT BZIP2_INCLUDE_DIR OR NOT BZIP2_LIBRARY)
+			message (FATAL_ERROR "FUSE_SUPPORT needs libbz2 (install libbz2-dev).")
+		endif()
+		message (STATUS "FUSE support: bzip2 ${BZIP2_LIBRARY}")
+		# The transfer half is uhub-seeder's, driven rather than reimplemented:
+		# the client-to-client protocol, the content cache and the grants that
+		# authorise a connection. Only those three, not the whole daemon --
+		# nothing here wants its hub connection, its config or its boards.
+		set (fuse_seeder_SOURCES
+			${UHUB_SOURCE_DIR}/seeder/cache.c
+			${UHUB_SOURCE_DIR}/seeder/cc.c
+			${UHUB_SOURCE_DIR}/seeder/grant.c
+			${UHUB_SOURCE_DIR}/seeder/sniff.c)
+		add_executable(uhub-fuse ${fuse_SOURCES} ${fuse_seeder_SOURCES} ${adcclient_SOURCES})
+		target_include_directories(uhub-fuse PRIVATE ${BZIP2_INCLUDE_DIR})
+		target_link_libraries(uhub-fuse adc network utils PkgConfig::FUSE3 SQLite::SQLite3 ${BZIP2_LIBRARY} pthread)
 	endif()
 
 	if (ADC_STRESS)
@@ -564,6 +637,13 @@ endif()
 if(UNIX)
 	target_link_libraries(uhub-admin ${SSL_LIBS})
 	target_link_libraries(adc_cmd ${SSL_LIBS})
+	if (TARGET filelist_peer)
+		target_link_libraries(filelist_peer ${SSL_LIBS})
+	endif()
+	target_link_libraries(seed_put ${SSL_LIBS})
+	if (FUSE_SUPPORT)
+		target_link_libraries(uhub-fuse ${SSL_LIBS})
+	endif()
 endif()
 target_link_libraries(mod_welcome ${SSL_LIBS})
 target_link_libraries(mod_logging ${SSL_LIBS})
@@ -630,6 +710,18 @@ if (FUZZING)
 	# only seeder/post.c and the magnet scanner it hands the body to.
 	add_fuzzer(fuzz_bbs_post ${UHUB_SOURCE_DIR}/tools/fuzz_bbs_post.c
 		${UHUB_SOURCE_DIR}/seeder/post.c ${UHUB_SOURCE_DIR}/seeder/embed.c)
+	# uhub-fuse's file list parser: XML and bzip2 from another user, turned
+	# into names in a mounted filesystem. Needs libbz2 but nothing else.
+	find_path(BZIP2_INCLUDE_DIR bzlib.h)
+	find_library(BZIP2_LIBRARY NAMES bz2 bzip2)
+	if (BZIP2_INCLUDE_DIR AND BZIP2_LIBRARY)
+		add_fuzzer(fuzz_filelist ${UHUB_SOURCE_DIR}/tools/fuzz_filelist.c
+			${UHUB_SOURCE_DIR}/fuse/filelist.c)
+		target_include_directories(fuzz_filelist PRIVATE ${BZIP2_INCLUDE_DIR})
+		target_link_libraries(fuzz_filelist ${BZIP2_LIBRARY})
+	else()
+		message (STATUS "fuzz_filelist skipped: libbz2 not found")
+	endif()
 endif()
 
 configure_file ("${UHUB_SOURCE_DIR}/version.h.in" "${PROJECT_BINARY_DIR}/version.h")
@@ -641,13 +733,21 @@ endif()
 
 if (UNIX)
 	install( TARGETS uhub uhub-passwd uhub-seeder RUNTIME DESTINATION bin )
+	if (FUSE_SUPPORT)
+		install( TARGETS uhub-fuse RUNTIME DESTINATION bin )
+	endif()
 	install( TARGETS mod_example mod_welcome mod_logging mod_auth_simple mod_auth_sqlite mod_selfregister mod_chat_history mod_chat_history_sqlite mod_chat_only mod_chat_is_privileged mod_topic mod_no_guest_downloads mod_flood mod_ucmd DESTINATION /usr/lib/uhub/ OPTIONAL )
 	if(JAVASCRIPT_SUPPORT)
 		install( TARGETS mod_javascript DESTINATION /usr/lib/uhub/ OPTIONAL )
 	endif()
 	install( FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/uhub.conf ${CMAKE_CURRENT_SOURCE_DIR}/doc/plugins.conf ${CMAKE_CURRENT_SOURCE_DIR}/doc/rules.txt ${CMAKE_CURRENT_SOURCE_DIR}/doc/motd.txt ${CMAKE_CURRENT_SOURCE_DIR}/doc/boards.conf DESTINATION /etc/uhub OPTIONAL )
 	# The seeder config carries a cleartext password for its bot account, so it
-	# is installed private rather than world readable like the hub's.
+	# is installed private rather than world readable like the hub's. The same
+	# goes for the mount's, for the same reason.
 	install( FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/uhub-seeder.conf DESTINATION /etc/uhub
 		PERMISSIONS OWNER_READ OWNER_WRITE OPTIONAL )
+	if (FUSE_SUPPORT)
+		install( FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/uhub-fuse.conf DESTINATION /etc/uhub
+			PERMISSIONS OWNER_READ OWNER_WRITE OPTIONAL )
+	endif()
 endif()

--- a/autotest/fuzz/README.md
+++ b/autotest/fuzz/README.md
@@ -15,6 +15,7 @@ configured with `-DFUZZING=ON` and run for a short time on every CI run.
 | `fuzz_metrics`        | `src/tools/fuzz_metrics.c`        | `metrics_classify_request()` (HTTP method/path/bearer-token validation) | raw network bytes on the metrics endpoint |
 | `fuzz_login`          | `src/tools/fuzz_login.c`          | `hub_handle_info_login()` -- the connect-time INF checks (CID/nick/network/user-agent/ACL) | INF from a not-yet-trusted client, **pre-auth** |
 | `fuzz_bbs`            | `src/tools/fuzz_bbs.c`            | `bbs_handle_subscribe()` / `bbs_handle_post()` -- the BBS0 board name, hash, size and subject handling | HBBL/HBBP from a logged-in but untrusted session |
+| `fuzz_filelist`       | `src/tools/fuzz_filelist.c`       | `fs_filelist_parse()` / `fs_filelist_load()` -- uhub-fuse's file list XML and bzip2 handling | a peer's `files.xml.bz2`, whose names become path components in a mount |
 
 `fuzz_adc_escape` also checks a property: `escape()` followed by `unescape()`
 must reproduce the original string exactly (a violation aborts the run).
@@ -24,7 +25,10 @@ against attacker bytes before authentication. `fuzz_message` covers the ADC
 parse; `fuzz_login` continues past it into the connect-time INF checks
 (CID/nick/network/user-agent/ACL), the code with the OOB history.
 `fuzz_command_parser` also exercises the ipcalc and `is_number` parsers via
-the address/number argument codes. `fuzz_bbs` runs post-login, but everything
+the address/number argument codes. `fuzz_filelist` checks properties as well as
+crashes: every name it produces must be a single path component that is not
+"." or "..", and every file must carry a well-formed TTH -- a name that escaped
+its directory would be a path traversal on the machine doing the mounting. `fuzz_bbs` runs post-login, but everything
 it reads is remote input that ends up in a persistent index and back on the
 wire to other users, so it lasts rather than passing through.
 
@@ -49,6 +53,7 @@ export UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
 ./build-fuzz/fuzz_command_parser                            autotest/fuzz/corpus/command_parser
 ./build-fuzz/fuzz_metrics      -dict=autotest/fuzz/metrics.dict autotest/fuzz/corpus/metrics
 ./build-fuzz/fuzz_login        -dict=autotest/fuzz/login.dict   autotest/fuzz/corpus/login
+./build-fuzz/fuzz_filelist                                  autotest/fuzz/corpus/filelist
 ```
 
 Add `-max_total_time=<seconds>` for a time-boxed run (what CI does). A crash

--- a/autotest/fuzz/corpus/filelist/entities
+++ b/autotest/fuzz/corpus/filelist/entities
@@ -1,0 +1,1 @@
+<FileListing><File Name="a&amp;b" Size="1" TTH="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/></FileListing>

--- a/autotest/fuzz/corpus/filelist/simple
+++ b/autotest/fuzz/corpus/filelist/simple
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<FileListing Version="1" CID="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" Base="/" Generator="DC++ 0.868">
+<Directory Name="Music">
+<File Name="song.flac" Size="41234567" TTH="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
+<Directory Name="Live">
+<File Name="set.mp3" Size="12" TTH="BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"/>
+</Directory>
+</Directory>
+<File Name="readme.txt" Size="7" TTH="CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"/>
+</FileListing>

--- a/autotest/fuzz/corpus/filelist/traversal
+++ b/autotest/fuzz/corpus/filelist/traversal
@@ -1,0 +1,1 @@
+<FileListing><Directory Name="../../etc"><File Name="passwd" Size="1" TTH="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/></Directory></FileListing>

--- a/autotest/test_fuse_chatlog.tcc
+++ b/autotest/test_fuse_chatlog.tcc
@@ -1,0 +1,130 @@
+#include "system.h"
+#include "util/memory.h"
+#include "fuse/chatlog.h"
+
+static struct fs_chatlog* log = NULL;
+static char buf[512];
+
+/* Read at an absolute offset and NUL terminate, for comparison. */
+static const char* read_at(uint64_t offset, size_t len)
+{
+	size_t got;
+
+	if (len >= sizeof(buf))
+		len = sizeof(buf) - 1;
+
+	got = fs_chatlog_read(log, offset, buf, len);
+	buf[got] = '\0';
+	return buf;
+}
+
+EXO_TEST(fuse_chatlog_create, {
+	log = fs_chatlog_create(32);
+	return log != NULL && fs_chatlog_size(log) == 0;
+});
+
+EXO_TEST(fuse_chatlog_read_empty, { return fs_chatlog_read(log, 0, buf, sizeof(buf)) == 0; });
+
+EXO_TEST(fuse_chatlog_append, {
+	fs_chatlog_append(log, "hello", 5);
+	return fs_chatlog_size(log) == 5 && strcmp(read_at(0, 16), "hello") == 0;
+});
+
+EXO_TEST(fuse_chatlog_read_partial, { return strcmp(read_at(0, 2), "he") == 0; });
+EXO_TEST(fuse_chatlog_read_at_offset, { return strcmp(read_at(2, 16), "llo") == 0; });
+
+/* At the end is end of file, which is what a poller sees between messages. */
+EXO_TEST(fuse_chatlog_read_at_end, { return fs_chatlog_read(log, 5, buf, sizeof(buf)) == 0; });
+EXO_TEST(fuse_chatlog_read_past_end, { return fs_chatlog_read(log, 99, buf, sizeof(buf)) == 0; });
+
+EXO_TEST(fuse_chatlog_append_more, {
+	fs_chatlog_append(log, "!", 1);
+	return fs_chatlog_size(log) == 6 && strcmp(read_at(0, 16), "hello!") == 0;
+});
+
+EXO_TEST(fuse_chatlog_line_adds_newline, {
+	fs_chatlog_append_line(log, "one");
+	return strcmp(read_at(6, 16), "one\n") == 0;
+});
+
+/* One message is one line, whatever the message contains. */
+EXO_TEST(fuse_chatlog_line_flattens_newlines, {
+	fs_chatlog_clear(log);
+	fs_chatlog_append_line(log, "a\nb\r\nc");
+	return strcmp(read_at(fs_chatlog_size(log) - 7, 16), "a b  c\n") == 0;
+});
+
+EXO_TEST(fuse_chatlog_line_empty, {
+	uint64_t before = fs_chatlog_size(log);
+	fs_chatlog_append_line(log, "");
+	return fs_chatlog_size(log) == before + 1;
+});
+
+/* ------------------------------------------------------------- the window */
+
+EXO_TEST(fuse_chatlog_wraps, {
+	fs_chatlog_destroy(log);
+	log = fs_chatlog_create(8);
+	fs_chatlog_append(log, "abcdefgh", 8);
+	fs_chatlog_append(log, "ij", 2);
+	/* Ten bytes through an eight byte window: the first two are gone. */
+	return fs_chatlog_size(log) == 10 && strcmp(read_at(2, 16), "cdefghij") == 0;
+});
+
+EXO_TEST(fuse_chatlog_offsets_keep_going, {
+	return log->base == 2 && log->end == 10;
+});
+
+/* A reader that fell behind gets the oldest bytes still held, not an error. */
+EXO_TEST(fuse_chatlog_behind_the_window, {
+	return strcmp(read_at(0, 16), "cdefghij") == 0;
+});
+
+EXO_TEST(fuse_chatlog_append_larger_than_capacity, {
+	/* Thirteen bytes into an eight byte window keeps the last eight of them,
+	   at offsets 15..23. */
+	fs_chatlog_append(log, "0123456789ABC", 13);
+	return fs_chatlog_size(log) == 23 && strcmp(read_at(15, 16), "56789ABC") == 0;
+});
+
+EXO_TEST(fuse_chatlog_read_spanning_the_wrap, {
+	fs_chatlog_destroy(log);
+	log = fs_chatlog_create(8);
+	fs_chatlog_append(log, "abcde", 5);
+	fs_chatlog_append(log, "fghij", 5);
+	/* Held is "cdefghij", and the ring's own start is in the middle of it. */
+	return strcmp(read_at(2, 16), "cdefghij") == 0;
+});
+
+EXO_TEST(fuse_chatlog_clear_keeps_offsets, {
+	uint64_t before = fs_chatlog_size(log);
+	fs_chatlog_clear(log);
+	return fs_chatlog_size(log) == before
+		&& fs_chatlog_read(log, 0, buf, sizeof(buf)) == 0
+		&& log->base == before;
+});
+
+EXO_TEST(fuse_chatlog_append_after_clear, {
+	fs_chatlog_append(log, "new", 3);
+	return strcmp(read_at(fs_chatlog_size(log) - 3, 8), "new") == 0;
+});
+
+EXO_TEST(fuse_chatlog_null_safe, {
+	fs_chatlog_append(NULL, "x", 1);
+	fs_chatlog_append_line(NULL, "x");
+	fs_chatlog_clear(NULL);
+	fs_chatlog_destroy(NULL);
+	return fs_chatlog_read(NULL, 0, buf, sizeof(buf)) == 0 && fs_chatlog_size(NULL) == 0;
+});
+
+EXO_TEST(fuse_chatlog_append_zero_length, {
+	uint64_t before = fs_chatlog_size(log);
+	fs_chatlog_append(log, "x", 0);
+	return fs_chatlog_size(log) == before;
+});
+
+EXO_TEST(fuse_chatlog_destroy_test, {
+	fs_chatlog_destroy(log);
+	log = NULL;
+	return 1;
+});

--- a/autotest/test_fuse_config.tcc
+++ b/autotest/test_fuse_config.tcc
@@ -4,6 +4,17 @@
 
 static struct fs_config cfg;
 
+/*
+ * fs_config_defaults() zeroes the struct before filling it in, so whatever a
+ * previous test left in it has to be released first or it is orphaned. The
+ * program does this once at startup; a test file does it over and over.
+ */
+static void reset_config(void)
+{
+	fs_config_free(&cfg);
+	fs_config_defaults(&cfg);
+}
+
 /* fs_config_parse_line() modifies the line in place, so tests hand it a copy. */
 static int parse(const char* text)
 {
@@ -118,7 +129,7 @@ static int write_config(const char* contents)
 }
 
 EXO_TEST(fuse_config_read_file, {
-	fs_config_defaults(&cfg);
+	reset_config();
 	return write_config("# a hub\nhub = adc://file:1511\nnick = fromfile\n")
 		&& fs_config_read(config_path(), &cfg) == 1
 		&& strcmp(cfg.address, "adc://file:1511") == 0
@@ -126,14 +137,14 @@ EXO_TEST(fuse_config_read_file, {
 });
 
 EXO_TEST(fuse_config_read_no_trailing_newline, {
-	fs_config_defaults(&cfg);
+	reset_config();
 	return write_config("hub = adc://last:1511")
 		&& fs_config_read(config_path(), &cfg) == 1
 		&& strcmp(cfg.address, "adc://last:1511") == 0;
 });
 
 EXO_TEST(fuse_config_read_crlf, {
-	fs_config_defaults(&cfg);
+	reset_config();
 	return write_config("hub = adc://crlf:1511\r\nnick = dos\r\n")
 		&& fs_config_read(config_path(), &cfg) == 1
 		&& strcmp(cfg.address, "adc://crlf:1511") == 0
@@ -142,7 +153,7 @@ EXO_TEST(fuse_config_read_crlf, {
 
 /* A file that does not parse leaves nothing half-applied behind. */
 EXO_TEST(fuse_config_read_bad_line, {
-	fs_config_defaults(&cfg);
+	reset_config();
 	return write_config("hub = adc://ok:1511\nnope = 1\n")
 		&& fs_config_read(config_path(), &cfg) == 0
 		&& cfg.address == NULL && cfg.nick == NULL;
@@ -151,7 +162,7 @@ EXO_TEST(fuse_config_read_bad_line, {
 /* --------------------------------------------------------- numeric keys */
 
 EXO_TEST(fuse_config_int, {
-	fs_config_defaults(&cfg);
+	reset_config();
 	return parse("transfer_port = 4711") == 1 && cfg.transfer_port == 4711;
 });
 
@@ -176,13 +187,13 @@ EXO_TEST(fuse_config_enumerated_value_refused, {
 /* A certificate without its key would come up serving plain ADC while looking
    like it was serving ADCS. */
 EXO_TEST(fuse_config_tls_pair_incomplete, {
-	fs_config_defaults(&cfg);
+	reset_config();
 	return write_config("hub = adc://x:1511\ntls_certificate = /tmp/cert.pem\n")
 		&& fs_config_read(config_path(), &cfg) == 0;
 });
 
 EXO_TEST(fuse_config_tls_pair_complete, {
-	fs_config_defaults(&cfg);
+	reset_config();
 	return write_config("hub = adc://x:1511\ntls_certificate = /tmp/c.pem\ntls_private_key = /tmp/k.pem\n")
 		&& fs_config_read(config_path(), &cfg) == 1;
 });
@@ -200,12 +211,12 @@ EXO_TEST(fuse_config_cache_dir_no_room, {
 });
 
 EXO_TEST(fuse_config_read_missing_file, {
-	fs_config_defaults(&cfg);
+	reset_config();
 	return fs_config_read("/nonexistent/uhub-fuse.conf", &cfg) == 0;
 });
 
 EXO_TEST(fuse_config_read_null_file, {
-	fs_config_defaults(&cfg);
+	reset_config();
 	return fs_config_read(NULL, &cfg) == 0;
 });
 

--- a/autotest/test_fuse_config.tcc
+++ b/autotest/test_fuse_config.tcc
@@ -1,0 +1,218 @@
+#include "system.h"
+#include "util/memory.h"
+#include "fuse/config.h"
+
+static struct fs_config cfg;
+
+/* fs_config_parse_line() modifies the line in place, so tests hand it a copy. */
+static int parse(const char* text)
+{
+	char buf[256];
+	int ok;
+
+	snprintf(buf, sizeof(buf), "%s", text);
+	ok = fs_config_parse_line(buf, 1, &cfg);
+	return ok;
+}
+
+/* Unset strings are "" and never NULL, so no caller has to test for both. */
+EXO_TEST(fuse_config_defaults, {
+	fs_config_defaults(&cfg);
+	return cfg.address && !*cfg.address
+		&& cfg.password && !*cfg.password
+		&& cfg.nick && strcmp(cfg.nick, "uhub-fuse") == 0
+		&& cfg.transfer_port == 1514
+		&& cfg.download_timeout == 60
+		&& cfg.cache_size == 512;
+});
+
+EXO_TEST(fuse_config_blank_line, { return parse("") == 1; });
+EXO_TEST(fuse_config_whitespace_line, { return parse("   \t  ") == 1; });
+EXO_TEST(fuse_config_comment, { return parse("# hub = nope") == 1; });
+EXO_TEST(fuse_config_comment_not_applied, { return cfg.address && !*cfg.address; });
+
+EXO_TEST(fuse_config_hub, {
+	return parse("hub = adc://localhost:1511") == 1
+		&& strcmp(cfg.address, "adc://localhost:1511") == 0;
+});
+
+EXO_TEST(fuse_config_no_spaces_around_equals, {
+	return parse("hub=adc://other:411") == 1 && strcmp(cfg.address, "adc://other:411") == 0;
+});
+
+EXO_TEST(fuse_config_trailing_whitespace_stripped, {
+	return parse("nick =   bob \t ") == 1 && strcmp(cfg.nick, "bob") == 0;
+});
+
+EXO_TEST(fuse_config_last_wins, {
+	return parse("nick = carol") == 1 && strcmp(cfg.nick, "carol") == 0;
+});
+
+/*
+ * '#' is an ordinary character in a password. Treating it as the start of a
+ * comment would truncate the secret and fail the login with nothing to show
+ * for it.
+ */
+EXO_TEST(fuse_config_password_keeps_hash, {
+	return parse("password = a#b#c") == 1 && strcmp(cfg.password, "a#b#c") == 0;
+});
+
+EXO_TEST(fuse_config_password_keeps_spaces, {
+	return parse("password = two words") == 1 && strcmp(cfg.password, "two words") == 0;
+});
+
+EXO_TEST(fuse_config_password_keeps_equals, {
+	return parse("password = a=b") == 1 && strcmp(cfg.password, "a=b") == 0;
+});
+
+EXO_TEST(fuse_config_empty_value, {
+	return parse("password =") == 1 && cfg.password && cfg.password[0] == '\0';
+});
+
+EXO_TEST(fuse_config_unknown_key, { return parse("nope = 1") == 0; });
+EXO_TEST(fuse_config_missing_equals, { return parse("hub adc://x") == 0; });
+EXO_TEST(fuse_config_missing_key, { return parse(" = value") == 0; });
+EXO_TEST(fuse_config_null_line, { return fs_config_parse_line(NULL, 1, &cfg) == 0; });
+
+EXO_TEST(fuse_config_set, {
+	return fs_config_set(&cfg, "hub", "adc://set:1511") == 1
+		&& strcmp(cfg.address, "adc://set:1511") == 0;
+});
+
+EXO_TEST(fuse_config_set_unknown, { return fs_config_set(&cfg, "nope", "x") == 0; });
+EXO_TEST(fuse_config_set_null_value, { return fs_config_set(&cfg, "hub", NULL) == 0; });
+
+EXO_TEST(fuse_config_free, {
+	fs_config_free(&cfg);
+	return cfg.address == NULL && cfg.nick == NULL && cfg.password == NULL;
+});
+
+EXO_TEST(fuse_config_free_twice, {
+	fs_config_free(&cfg);
+	return 1;
+});
+
+EXO_TEST(fuse_config_free_null, {
+	fs_config_free(NULL);
+	return 1;
+});
+
+/* ------------------------------------------------------------------- files */
+
+static const char* config_path(void)
+{
+	static char path[256];
+	snprintf(path, sizeof(path), "%s/test_fuse_config.tmp", UHUB_TEST_DIR);
+	return path;
+}
+
+static int write_config(const char* contents)
+{
+	FILE* fh = fopen(config_path(), "wb");
+	if (!fh)
+		return 0;
+
+	fputs(contents, fh);
+	fclose(fh);
+	return 1;
+}
+
+EXO_TEST(fuse_config_read_file, {
+	fs_config_defaults(&cfg);
+	return write_config("# a hub\nhub = adc://file:1511\nnick = fromfile\n")
+		&& fs_config_read(config_path(), &cfg) == 1
+		&& strcmp(cfg.address, "adc://file:1511") == 0
+		&& strcmp(cfg.nick, "fromfile") == 0;
+});
+
+EXO_TEST(fuse_config_read_no_trailing_newline, {
+	fs_config_defaults(&cfg);
+	return write_config("hub = adc://last:1511")
+		&& fs_config_read(config_path(), &cfg) == 1
+		&& strcmp(cfg.address, "adc://last:1511") == 0;
+});
+
+EXO_TEST(fuse_config_read_crlf, {
+	fs_config_defaults(&cfg);
+	return write_config("hub = adc://crlf:1511\r\nnick = dos\r\n")
+		&& fs_config_read(config_path(), &cfg) == 1
+		&& strcmp(cfg.address, "adc://crlf:1511") == 0
+		&& strcmp(cfg.nick, "dos") == 0;
+});
+
+/* A file that does not parse leaves nothing half-applied behind. */
+EXO_TEST(fuse_config_read_bad_line, {
+	fs_config_defaults(&cfg);
+	return write_config("hub = adc://ok:1511\nnope = 1\n")
+		&& fs_config_read(config_path(), &cfg) == 0
+		&& cfg.address == NULL && cfg.nick == NULL;
+});
+
+/* --------------------------------------------------------- numeric keys */
+
+EXO_TEST(fuse_config_int, {
+	fs_config_defaults(&cfg);
+	return parse("transfer_port = 4711") == 1 && cfg.transfer_port == 4711;
+});
+
+EXO_TEST(fuse_config_int_trailing_garbage, {
+	/* "8080x" is a typo, not the number 8080. */
+	return parse("transfer_port = 8080x") == 0 && cfg.transfer_port == 4711;
+});
+
+EXO_TEST(fuse_config_int_out_of_range, { return parse("transfer_port = 99999") == 0; });
+EXO_TEST(fuse_config_int_below_range, { return parse("transfer_port = 80") == 0; });
+EXO_TEST(fuse_config_int_not_a_number, { return parse("transfer_port = nope") == 0; });
+EXO_TEST(fuse_config_int_empty, { return parse("transfer_port =") == 0; });
+
+EXO_TEST(fuse_config_enumerated_value, {
+	return parse("tls_version = 1.3") == 1 && strcmp(cfg.tls_version, "1.3") == 0;
+});
+
+EXO_TEST(fuse_config_enumerated_value_refused, {
+	return parse("tls_version = 1.0") == 0 && strcmp(cfg.tls_version, "1.3") == 0;
+});
+
+/* A certificate without its key would come up serving plain ADC while looking
+   like it was serving ADCS. */
+EXO_TEST(fuse_config_tls_pair_incomplete, {
+	fs_config_defaults(&cfg);
+	return write_config("hub = adc://x:1511\ntls_certificate = /tmp/cert.pem\n")
+		&& fs_config_read(config_path(), &cfg) == 0;
+});
+
+EXO_TEST(fuse_config_tls_pair_complete, {
+	fs_config_defaults(&cfg);
+	return write_config("hub = adc://x:1511\ntls_certificate = /tmp/c.pem\ntls_private_key = /tmp/k.pem\n")
+		&& fs_config_read(config_path(), &cfg) == 1;
+});
+
+EXO_TEST(fuse_config_cache_dir_default, {
+	char dir[256];
+	/* HOME is set in any environment this runs in; if it is not, the fallback
+	   is to fail rather than to invent a path. */
+	return getenv("HOME") ? (fs_config_default_cache_dir(dir, sizeof(dir)) == 1 && strstr(dir, "uhub-fuse") != NULL) : 1;
+});
+
+EXO_TEST(fuse_config_cache_dir_no_room, {
+	char dir[4];
+	return fs_config_default_cache_dir(dir, sizeof(dir)) == 0;
+});
+
+EXO_TEST(fuse_config_read_missing_file, {
+	fs_config_defaults(&cfg);
+	return fs_config_read("/nonexistent/uhub-fuse.conf", &cfg) == 0;
+});
+
+EXO_TEST(fuse_config_read_null_file, {
+	fs_config_defaults(&cfg);
+	return fs_config_read(NULL, &cfg) == 0;
+});
+
+EXO_TEST(fuse_config_read_null_cfg, { return fs_config_read(config_path(), NULL) == 0; });
+
+EXO_TEST(fuse_config_read_cleanup, {
+	fs_config_free(&cfg);
+	remove(config_path());
+	return 1;
+});

--- a/autotest/test_fuse_filelist.tcc
+++ b/autotest/test_fuse_filelist.tcc
@@ -1,0 +1,346 @@
+#include "system.h"
+#include "util/memory.h"
+#include "fuse/filelist.h"
+
+#include <bzlib.h>
+
+/*
+ * The file list parser. Every byte it sees came from a peer over a connection
+ * anybody can open, and the names in it become path components in a mounted
+ * filesystem, so the tests below are mostly about what it refuses.
+ */
+
+static struct fs_filelist* list = NULL;
+
+static struct fs_filelist* parse(const char* xml)
+{
+	fs_filelist_destroy(list);
+	list = fs_filelist_parse(xml, strlen(xml));
+	return list;
+}
+
+static const char* SIMPLE =
+	"<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>\n"
+	"<FileListing Version=\"1\" CID=\"AAAA\" Base=\"/\" Generator=\"DC++ 0.868\">\n"
+	"<Directory Name=\"Music\">\n"
+	"  <File Name=\"song.flac\" Size=\"41234567\" TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/>\n"
+	"  <Directory Name=\"Live\">\n"
+	"    <File Name=\"set.mp3\" Size=\"12\" TTH=\"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\"/>\n"
+	"  </Directory>\n"
+	"</Directory>\n"
+	"<File Name=\"readme.txt\" Size=\"7\" TTH=\"CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC\"/>\n"
+	"</FileListing>\n";
+
+EXO_TEST(fuse_filelist_parse_simple, { return parse(SIMPLE) != NULL; });
+
+EXO_TEST(fuse_filelist_counts_every_entry, {
+	/* Music, song.flac, Live, set.mp3, readme.txt */
+	return fs_filelist_count(list) == 5;
+});
+
+EXO_TEST(fuse_filelist_root_in_document_order, {
+	struct fs_filelist_node* root = fs_filelist_root(list);
+	return root && strcmp(root->name, "Music") == 0 && root->is_dir
+		&& root->next && strcmp(root->next->name, "readme.txt") == 0 && !root->next->is_dir
+		&& !root->next->next;
+});
+
+EXO_TEST(fuse_filelist_lookup_file, {
+	struct fs_filelist_node* node = fs_filelist_lookup(list, "Music/song.flac");
+	return node && !node->is_dir && node->size == 41234567
+		&& strcmp(node->tth, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA") == 0;
+});
+
+EXO_TEST(fuse_filelist_lookup_nested, {
+	struct fs_filelist_node* node = fs_filelist_lookup(list, "Music/Live/set.mp3");
+	return node && node->size == 12;
+});
+
+EXO_TEST(fuse_filelist_lookup_directory, {
+	struct fs_filelist_node* node = fs_filelist_lookup(list, "Music/Live");
+	return node && node->is_dir && node->children
+		&& strcmp(node->children->name, "set.mp3") == 0;
+});
+
+EXO_TEST(fuse_filelist_lookup_missing, { return fs_filelist_lookup(list, "Nope") == NULL; });
+EXO_TEST(fuse_filelist_lookup_missing_nested, { return fs_filelist_lookup(list, "Music/nope") == NULL; });
+EXO_TEST(fuse_filelist_lookup_below_a_file, {
+	return fs_filelist_lookup(list, "readme.txt/deeper") == NULL;
+});
+EXO_TEST(fuse_filelist_lookup_empty, { return fs_filelist_lookup(list, "") == NULL; });
+EXO_TEST(fuse_filelist_lookup_empty_component, { return fs_filelist_lookup(list, "Music//song.flac") == NULL; });
+EXO_TEST(fuse_filelist_lookup_null, { return fs_filelist_lookup(NULL, "x") == NULL; });
+
+EXO_TEST(fuse_filelist_trailing_slash_is_the_directory, {
+	struct fs_filelist_node* node = fs_filelist_lookup(list, "Music/");
+	return node && node->is_dir;
+});
+
+/* --- what is skipped rather than kept ------------------------------------ */
+
+/* A file with no hash cannot be fetched, so listing it would only offer
+   something that can never be read. */
+EXO_TEST(fuse_filelist_file_without_tth_is_skipped, {
+	parse("<FileListing><File Name=\"a.txt\" Size=\"1\"/></FileListing>");
+	return fs_filelist_count(list) == 0;
+});
+
+EXO_TEST(fuse_filelist_file_with_short_tth_is_skipped, {
+	parse("<FileListing><File Name=\"a\" TTH=\"AAA\"/></FileListing>");
+	return fs_filelist_count(list) == 0;
+});
+
+EXO_TEST(fuse_filelist_file_with_non_base32_tth_is_skipped, {
+	parse("<FileListing><File Name=\"a\" TTH=\"1111111111111111111111111111111111111112\"/></FileListing>");
+	return fs_filelist_count(list) == 0;
+});
+
+EXO_TEST(fuse_filelist_file_without_name_is_skipped, {
+	parse("<FileListing><File Size=\"1\" TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_count(list) == 0;
+});
+
+/* One unusable entry is no reason to lose the rest of the list. */
+EXO_TEST(fuse_filelist_keeps_going_after_a_bad_entry, {
+	parse("<FileListing>"
+	      "<File Name=\"bad\"/>"
+	      "<File Name=\"good\" Size=\"3\" TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/>"
+	      "</FileListing>");
+	return fs_filelist_count(list) == 1 && fs_filelist_lookup(list, "good") != NULL;
+});
+
+EXO_TEST(fuse_filelist_unknown_elements_are_stepped_over, {
+	parse("<FileListing><Whatever attr=\"1\"><File Name=\"a\" Size=\"1\" "
+	      "TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></Whatever></FileListing>");
+	return fs_filelist_lookup(list, "a") != NULL;
+});
+
+EXO_TEST(fuse_filelist_comments_are_stepped_over, {
+	parse("<FileListing><!-- <File Name=\"ghost\" TTH=\"x\"/> -->"
+	      "<File Name=\"real\" Size=\"1\" TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_count(list) == 1 && fs_filelist_lookup(list, "real") != NULL;
+});
+
+/* A DOCTYPE is where an XML parser starts reading things nobody gave it. */
+EXO_TEST(fuse_filelist_doctype_is_stepped_over, {
+	parse("<!DOCTYPE FileListing [<!ENTITY x SYSTEM \"file:///etc/passwd\">]>"
+	      "<FileListing><File Name=\"a\" Size=\"1\" "
+	      "TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_count(list) == 1;
+});
+
+EXO_TEST(fuse_filelist_entity_is_not_expanded, {
+	/* &x; is not one of the five, and there is no table to look it up in. */
+	parse("<FileListing><File Name=\"&x;\" Size=\"1\" "
+	      "TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_lookup(list, "&x;") != NULL;
+});
+
+/* --- names ---------------------------------------------------------------- */
+
+EXO_TEST(fuse_filelist_named_entities, {
+	parse("<FileListing><File Name=\"a&amp;b&lt;c&gt;d&quot;e&apos;f\" Size=\"1\" "
+	      "TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_lookup(list, "a&b<c>d\"e'f") != NULL;
+});
+
+EXO_TEST(fuse_filelist_numeric_entity, {
+	parse("<FileListing><File Name=\"a&#65;b\" Size=\"1\" "
+	      "TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_lookup(list, "aAb") != NULL;
+});
+
+EXO_TEST(fuse_filelist_numeric_entity_utf8, {
+	/* &#229; is 'å', which is two bytes in UTF-8. */
+	parse("<FileListing><File Name=\"&#229;\" Size=\"1\" "
+	      "TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_lookup(list, "\xc3\xa5") != NULL;
+});
+
+/* A name that decodes to a slash would be two path components, and one that
+   decodes to ".." would be the directory above. Neither is allowed to happen. */
+EXO_TEST(fuse_filelist_encoded_slash_is_neutralised, {
+	parse("<FileListing><File Name=\"a&#47;b\" Size=\"1\" "
+	      "TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_lookup(list, "a_b") != NULL && fs_filelist_lookup(list, "a/b") == NULL;
+});
+
+EXO_TEST(fuse_filelist_literal_slash_is_neutralised, {
+	parse("<FileListing><File Name=\"../../etc/passwd\" Size=\"1\" "
+	      "TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_lookup(list, ".._.._etc_passwd") != NULL;
+});
+
+EXO_TEST(fuse_filelist_dotdot_name_is_refused, {
+	parse("<FileListing><File Name=\"..\" Size=\"1\" "
+	      "TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_count(list) == 0;
+});
+
+EXO_TEST(fuse_filelist_dot_name_is_refused, {
+	parse("<FileListing><File Name=\".\" Size=\"1\" "
+	      "TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_count(list) == 0;
+});
+
+EXO_TEST(fuse_filelist_empty_name_is_refused, {
+	parse("<FileListing><File Name=\"\" Size=\"1\" "
+	      "TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_count(list) == 0;
+});
+
+EXO_TEST(fuse_filelist_control_characters_are_neutralised, {
+	parse("<FileListing><File Name=\"a&#10;b\" Size=\"1\" "
+	      "TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/></FileListing>");
+	return fs_filelist_lookup(list, "a_b") != NULL;
+});
+
+EXO_TEST(fuse_filelist_safe_name_direct, {
+	char buf[64];
+	return fs_filelist_safe_name("ok", buf, sizeof(buf)) && strcmp(buf, "ok") == 0
+		&& !fs_filelist_safe_name("", buf, sizeof(buf))
+		&& !fs_filelist_safe_name("..", buf, sizeof(buf))
+		&& !fs_filelist_safe_name(NULL, buf, sizeof(buf));
+});
+
+EXO_TEST(fuse_filelist_safe_name_refuses_rather_than_truncates, {
+	char buf[4];
+	/* Truncating would make two different names into one. */
+	return !fs_filelist_safe_name("abcdef", buf, sizeof(buf));
+});
+
+/* --- shapes that should not bring it down --------------------------------- */
+
+EXO_TEST(fuse_filelist_empty_document, { return parse("") == NULL; });
+EXO_TEST(fuse_filelist_null_document, { return fs_filelist_parse(NULL, 10) == NULL; });
+EXO_TEST(fuse_filelist_not_xml, { return parse("hello") != NULL && fs_filelist_count(list) == 0; });
+EXO_TEST(fuse_filelist_truncated_tag, { return parse("<FileListing><File Name=\"a") != NULL; });
+EXO_TEST(fuse_filelist_unclosed_quote, {
+	return parse("<FileListing><File Name=\"abc/></FileListing>") != NULL;
+});
+EXO_TEST(fuse_filelist_lone_bracket, { return parse("<") != NULL; });
+EXO_TEST(fuse_filelist_unbalanced_close, {
+	return parse("</Directory></Directory></Directory>") != NULL;
+});
+
+EXO_TEST(fuse_filelist_self_closing_directory, {
+	parse("<FileListing><Directory Name=\"empty\"/>"
+	      "<File Name=\"a\" Size=\"1\" TTH=\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"/>"
+	      "</FileListing>");
+	/* The empty directory must not swallow what follows it. */
+	return fs_filelist_lookup(list, "empty") != NULL
+		&& fs_filelist_lookup(list, "a") != NULL
+		&& fs_filelist_lookup(list, "empty/a") == NULL;
+});
+
+EXO_TEST(fuse_filelist_deep_nesting_is_refused, {
+	/* Deeper than FS_FILELIST_MAX_DEPTH: refused outright rather than
+	   truncated, and above all not recursed into. */
+	char* xml = hub_malloc(64 * 1024);
+	size_t n = 0;
+	int i;
+	int refused;
+
+	n += sprintf(&xml[n], "<FileListing>");
+	for (i = 0; i < FS_FILELIST_MAX_DEPTH + 10; i++)
+		n += sprintf(&xml[n], "<Directory Name=\"d%d\">", i);
+	for (i = 0; i < FS_FILELIST_MAX_DEPTH + 10; i++)
+		n += sprintf(&xml[n], "</Directory>");
+	n += sprintf(&xml[n], "</FileListing>");
+
+	refused = (fs_filelist_parse(xml, n) == NULL);
+	hub_free(xml);
+	return refused;
+});
+
+EXO_TEST(fuse_filelist_deep_but_allowed, {
+	char* xml = hub_malloc(64 * 1024);
+	size_t n = 0;
+	int i;
+	struct fs_filelist* deep;
+
+	n += sprintf(&xml[n], "<FileListing>");
+	for (i = 0; i < 32; i++)
+		n += sprintf(&xml[n], "<Directory Name=\"d%d\">", i);
+	for (i = 0; i < 32; i++)
+		n += sprintf(&xml[n], "</Directory>");
+	n += sprintf(&xml[n], "</FileListing>");
+
+	deep = fs_filelist_parse(xml, n);
+	hub_free(xml);
+	if (!deep)
+		return 0;
+
+	i = (fs_filelist_lookup(deep, "d0/d1/d2") != NULL);
+	fs_filelist_destroy(deep);
+	return i;
+});
+
+/* --- decompression -------------------------------------------------------- */
+
+EXO_TEST(fuse_filelist_decompress_garbage, {
+	size_t len = 0;
+	return fs_filelist_decompress("not a bzip2 stream", 18, &len) == NULL;
+});
+
+EXO_TEST(fuse_filelist_decompress_empty, {
+	size_t len = 0;
+	return fs_filelist_decompress("", 0, &len) == NULL
+		&& fs_filelist_decompress(NULL, 10, &len) == NULL;
+});
+
+EXO_TEST(fuse_filelist_load_garbage, {
+	return fs_filelist_load("not a bzip2 stream", 18) == NULL;
+});
+
+/* The real path: a list as it actually arrives, compressed. */
+EXO_TEST(fuse_filelist_load_round_trip, {
+	unsigned int packed_len = 64 * 1024;
+	char* packed = hub_malloc(packed_len);
+	struct fs_filelist* loaded;
+	int ok;
+
+	if (BZ2_bzBuffToBuffCompress(packed, &packed_len, (char*) SIMPLE,
+	                             (unsigned int) strlen(SIMPLE), 9, 0, 30) != BZ_OK)
+	{
+		hub_free(packed);
+		return 0;
+	}
+
+	loaded = fs_filelist_load(packed, packed_len);
+	hub_free(packed);
+
+	if (!loaded)
+		return 0;
+
+	ok = (fs_filelist_count(loaded) == 5)
+		&& (fs_filelist_lookup(loaded, "Music/Live/set.mp3") != NULL);
+
+	fs_filelist_destroy(loaded);
+	return ok;
+});
+
+EXO_TEST(fuse_filelist_load_truncated_stream, {
+	unsigned int packed_len = 64 * 1024;
+	char* packed = hub_malloc(packed_len);
+	int refused;
+
+	if (BZ2_bzBuffToBuffCompress(packed, &packed_len, (char*) SIMPLE,
+	                             (unsigned int) strlen(SIMPLE), 9, 0, 30) != BZ_OK)
+	{
+		hub_free(packed);
+		return 0;
+	}
+
+	/* Half a stream is not a list, and must not become a partial one. */
+	refused = (fs_filelist_load(packed, packed_len / 2) == NULL);
+	hub_free(packed);
+	return refused;
+});
+
+EXO_TEST(fuse_filelist_teardown, {
+	fs_filelist_destroy(list);
+	list = NULL;
+	fs_filelist_destroy(NULL);
+	return 1;
+});

--- a/autotest/test_fuse_filelist.tcc
+++ b/autotest/test_fuse_filelist.tcc
@@ -235,20 +235,37 @@ EXO_TEST(fuse_filelist_self_closing_directory, {
 		&& fs_filelist_lookup(list, "empty/a") == NULL;
 });
 
+/* Build "<FileListing>" wrapping @p depth nested directories. */
+static char* nested_document(int depth, size_t* out_len)
+{
+	size_t cap = 64 * 1024;
+	char* xml = hub_malloc(cap);
+	size_t n = 0;
+	int i;
+
+	if (!xml)
+		return NULL;
+
+	n += (size_t) snprintf(&xml[n], cap - n, "<FileListing>");
+	for (i = 0; i < depth; i++)
+		n += (size_t) snprintf(&xml[n], cap - n, "<Directory Name=\"d%d\">", i);
+	for (i = 0; i < depth; i++)
+		n += (size_t) snprintf(&xml[n], cap - n, "</Directory>");
+	n += (size_t) snprintf(&xml[n], cap - n, "</FileListing>");
+
+	*out_len = n;
+	return xml;
+}
+
 EXO_TEST(fuse_filelist_deep_nesting_is_refused, {
 	/* Deeper than FS_FILELIST_MAX_DEPTH: refused outright rather than
 	   truncated, and above all not recursed into. */
-	char* xml = hub_malloc(64 * 1024);
 	size_t n = 0;
-	int i;
+	char* xml = nested_document(FS_FILELIST_MAX_DEPTH + 10, &n);
 	int refused;
 
-	n += sprintf(&xml[n], "<FileListing>");
-	for (i = 0; i < FS_FILELIST_MAX_DEPTH + 10; i++)
-		n += sprintf(&xml[n], "<Directory Name=\"d%d\">", i);
-	for (i = 0; i < FS_FILELIST_MAX_DEPTH + 10; i++)
-		n += sprintf(&xml[n], "</Directory>");
-	n += sprintf(&xml[n], "</FileListing>");
+	if (!xml)
+		return 0;
 
 	refused = (fs_filelist_parse(xml, n) == NULL);
 	hub_free(xml);
@@ -256,26 +273,22 @@ EXO_TEST(fuse_filelist_deep_nesting_is_refused, {
 });
 
 EXO_TEST(fuse_filelist_deep_but_allowed, {
-	char* xml = hub_malloc(64 * 1024);
 	size_t n = 0;
-	int i;
+	char* xml = nested_document(32, &n);
 	struct fs_filelist* deep;
+	int ok;
 
-	n += sprintf(&xml[n], "<FileListing>");
-	for (i = 0; i < 32; i++)
-		n += sprintf(&xml[n], "<Directory Name=\"d%d\">", i);
-	for (i = 0; i < 32; i++)
-		n += sprintf(&xml[n], "</Directory>");
-	n += sprintf(&xml[n], "</FileListing>");
+	if (!xml)
+		return 0;
 
 	deep = fs_filelist_parse(xml, n);
 	hub_free(xml);
 	if (!deep)
 		return 0;
 
-	i = (fs_filelist_lookup(deep, "d0/d1/d2") != NULL);
+	ok = (fs_filelist_lookup(deep, "d0/d1/d2") != NULL);
 	fs_filelist_destroy(deep);
-	return i;
+	return ok;
 });
 
 /* --- decompression -------------------------------------------------------- */

--- a/autotest/test_fuse_filelist.tcc
+++ b/autotest/test_fuse_filelist.tcc
@@ -2,7 +2,9 @@
 #include "util/memory.h"
 #include "fuse/filelist.h"
 
+#ifdef HAVE_BZLIB
 #include <bzlib.h>
+#endif
 
 /*
  * The file list parser. Every byte it sees came from a peer over a connection
@@ -278,6 +280,17 @@ EXO_TEST(fuse_filelist_deep_but_allowed, {
 
 /* --- decompression -------------------------------------------------------- */
 
+/*
+ * Built without libbz2 the decompressor is a stub, so the tests below have
+ * nothing to decompress with. The parser above them needs no library and is
+ * tested either way -- it is the part that reads what a stranger sent.
+ */
+#ifndef HAVE_BZLIB
+#define SKIP_WITHOUT_BZLIB EXO_SKIP("built without libbz2")
+#else
+#define SKIP_WITHOUT_BZLIB do { } while (0)
+#endif
+
 EXO_TEST(fuse_filelist_decompress_garbage, {
 	size_t len = 0;
 	return fs_filelist_decompress("not a bzip2 stream", 18, &len) == NULL;
@@ -295,6 +308,8 @@ EXO_TEST(fuse_filelist_load_garbage, {
 
 /* The real path: a list as it actually arrives, compressed. */
 EXO_TEST(fuse_filelist_load_round_trip, {
+	SKIP_WITHOUT_BZLIB;
+#ifdef HAVE_BZLIB
 	unsigned int packed_len = 64 * 1024;
 	char* packed = hub_malloc(packed_len);
 	struct fs_filelist* loaded;
@@ -318,9 +333,12 @@ EXO_TEST(fuse_filelist_load_round_trip, {
 
 	fs_filelist_destroy(loaded);
 	return ok;
+#endif
 });
 
 EXO_TEST(fuse_filelist_load_truncated_stream, {
+	SKIP_WITHOUT_BZLIB;
+#ifdef HAVE_BZLIB
 	unsigned int packed_len = 64 * 1024;
 	char* packed = hub_malloc(packed_len);
 	int refused;
@@ -336,6 +354,7 @@ EXO_TEST(fuse_filelist_load_truncated_stream, {
 	refused = (fs_filelist_load(packed, packed_len / 2) == NULL);
 	hub_free(packed);
 	return refused;
+#endif
 });
 
 EXO_TEST(fuse_filelist_teardown, {

--- a/autotest/test_fuse_filelist.tcc
+++ b/autotest/test_fuse_filelist.tcc
@@ -2,6 +2,8 @@
 #include "util/memory.h"
 #include "fuse/filelist.h"
 
+#include <stdarg.h>
+
 #ifdef HAVE_BZLIB
 #include <bzlib.h>
 #endif
@@ -235,23 +237,56 @@ EXO_TEST(fuse_filelist_self_closing_directory, {
 		&& fs_filelist_lookup(list, "empty/a") == NULL;
 });
 
+/*
+ * Append to @p buf, advancing @p n by what was actually written.
+ *
+ * snprintf() returns the length it *would* have needed, so "n += snprintf(...)"
+ * walks n past the end of the buffer as soon as anything is truncated, and the
+ * next "cap - n" underflows. @return 0 if it did not fit.
+ */
+static int append_fmt(char* buf, size_t cap, size_t* n, const char* fmt, ...)
+{
+	va_list args;
+	int written;
+
+	if (*n >= cap)
+		return 0;
+
+	va_start(args, fmt);
+	written = vsnprintf(&buf[*n], cap - *n, fmt, args);
+	va_end(args);
+
+	if (written < 0 || (size_t) written >= cap - *n)
+		return 0;
+
+	*n += (size_t) written;
+	return 1;
+}
+
 /* Build "<FileListing>" wrapping @p depth nested directories. */
 static char* nested_document(int depth, size_t* out_len)
 {
 	size_t cap = 64 * 1024;
 	char* xml = hub_malloc(cap);
 	size_t n = 0;
+	int ok = 1;
 	int i;
 
 	if (!xml)
 		return NULL;
 
-	n += (size_t) snprintf(&xml[n], cap - n, "<FileListing>");
-	for (i = 0; i < depth; i++)
-		n += (size_t) snprintf(&xml[n], cap - n, "<Directory Name=\"d%d\">", i);
-	for (i = 0; i < depth; i++)
-		n += (size_t) snprintf(&xml[n], cap - n, "</Directory>");
-	n += (size_t) snprintf(&xml[n], cap - n, "</FileListing>");
+	ok = append_fmt(xml, cap, &n, "<FileListing>");
+	for (i = 0; ok && i < depth; i++)
+		ok = append_fmt(xml, cap, &n, "<Directory Name=\"d%d\">", i);
+	for (i = 0; ok && i < depth; i++)
+		ok = append_fmt(xml, cap, &n, "</Directory>");
+	ok = ok && append_fmt(xml, cap, &n, "</FileListing>");
+
+	if (!ok)
+	{
+		hub_free(xml);
+		return NULL;
+	}
 
 	*out_len = n;
 	return xml;

--- a/autotest/test_fuse_nodes.tcc
+++ b/autotest/test_fuse_nodes.tcc
@@ -1,0 +1,147 @@
+#include "system.h"
+#include "util/memory.h"
+#include "fuse/nodes.h"
+
+static struct fs_node node;
+
+static enum fs_node_type resolve(const char* path)
+{
+	fs_node_resolve(path, &node);
+	return node.type;
+}
+
+#define CID_A "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+#define CID_B "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+
+EXO_TEST(fuse_nodes_root, { return resolve("/") == FS_NODE_ROOT; });
+EXO_TEST(fuse_nodes_relative, { return resolve("hub") == FS_NODE_NONE; });
+EXO_TEST(fuse_nodes_null, { return resolve(NULL) == FS_NODE_NONE; });
+EXO_TEST(fuse_nodes_unknown_top, { return resolve("/nope") == FS_NODE_NONE; });
+
+EXO_TEST(fuse_nodes_hub_dir, { return resolve("/hub") == FS_NODE_HUB_DIR; });
+EXO_TEST(fuse_nodes_hub_dir_slash, { return resolve("/hub/") == FS_NODE_HUB_DIR; });
+EXO_TEST(fuse_nodes_hub_name, {
+	return resolve("/hub/name") == FS_NODE_HUB_FILE && strcmp(node.field->name, "name") == 0;
+});
+EXO_TEST(fuse_nodes_hub_unknown, { return resolve("/hub/nope") == FS_NODE_NONE; });
+EXO_TEST(fuse_nodes_hub_too_deep, { return resolve("/hub/name/x") == FS_NODE_NONE; });
+
+EXO_TEST(fuse_nodes_me_dir, { return resolve("/me") == FS_NODE_ME_DIR; });
+EXO_TEST(fuse_nodes_me_cid, { return resolve("/me/cid") == FS_NODE_ME_FILE; });
+
+EXO_TEST(fuse_nodes_chat_dir, { return resolve("/chat") == FS_NODE_CHAT_DIR; });
+EXO_TEST(fuse_nodes_chat_main, { return resolve("/chat/main") == FS_NODE_CHAT_MAIN; });
+EXO_TEST(fuse_nodes_chat_private, { return resolve("/chat/private") == FS_NODE_CHAT_PRIVATE; });
+EXO_TEST(fuse_nodes_chat_other, { return resolve("/chat/other") == FS_NODE_NONE; });
+EXO_TEST(fuse_nodes_chat_too_deep, { return resolve("/chat/main/x") == FS_NODE_NONE; });
+
+EXO_TEST(fuse_nodes_users_dir, { return resolve("/users") == FS_NODE_USERS_DIR; });
+EXO_TEST(fuse_nodes_user_dir, {
+	return resolve("/users/" CID_A) == FS_NODE_USER_DIR && strcmp(node.cid, CID_A) == 0;
+});
+EXO_TEST(fuse_nodes_user_short_cid, { return resolve("/users/AAA") == FS_NODE_NONE; });
+EXO_TEST(fuse_nodes_user_long_cid, { return resolve("/users/" CID_A "A") == FS_NODE_NONE; });
+EXO_TEST(fuse_nodes_user_bad_cid, {
+	/* '1' and '0' are not in the base32 alphabet. Still 39 characters, so
+	   this fails on the alphabet and not on the length. */
+	return resolve("/users/1" "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB") == FS_NODE_NONE;
+});
+EXO_TEST(fuse_nodes_user_nick, {
+	return resolve("/users/" CID_A "/nick") == FS_NODE_USER_FILE
+		&& strcmp(node.field->name, "nick") == 0
+		&& strcmp(node.cid, CID_A) == 0;
+});
+EXO_TEST(fuse_nodes_user_inf_is_raw, {
+	return resolve("/users/" CID_A "/inf") == FS_NODE_USER_FILE
+		&& (node.field->flags & FS_FIELD_RAW_INF);
+});
+EXO_TEST(fuse_nodes_user_msg_is_write, {
+	return resolve("/users/" CID_A "/msg") == FS_NODE_USER_MSG
+		&& (node.field->flags & FS_FIELD_WRITE);
+});
+EXO_TEST(fuse_nodes_user_unknown_file, { return resolve("/users/" CID_A "/nope") == FS_NODE_NONE; });
+EXO_TEST(fuse_nodes_user_files_dir, { return resolve("/users/" CID_A "/files") == FS_NODE_USER_FILES_DIR; });
+EXO_TEST(fuse_nodes_user_files_dir_slash, { return resolve("/users/" CID_A "/files/") == FS_NODE_USER_FILES_DIR; });
+EXO_TEST(fuse_nodes_user_files_entry, {
+	return resolve("/users/" CID_A "/files/Movies/foo.mkv") == FS_NODE_USER_FILES_ENTRY
+		&& strcmp(node.tail, "Movies/foo.mkv") == 0;
+});
+
+EXO_TEST(fuse_nodes_by_nick_dir, { return resolve("/by-nick") == FS_NODE_BY_NICK_DIR; });
+EXO_TEST(fuse_nodes_by_nick_link, {
+	return resolve("/by-nick/alice") == FS_NODE_BY_NICK_LINK && strcmp(node.name, "alice") == 0;
+});
+EXO_TEST(fuse_nodes_by_tth_dir, { return resolve("/by-tth") == FS_NODE_BY_TTH_DIR; });
+EXO_TEST(fuse_nodes_by_tth_file, {
+	return resolve("/by-tth/" CID_B) == FS_NODE_BY_TTH_FILE && strcmp(node.name, CID_B) == 0;
+});
+EXO_TEST(fuse_nodes_by_tth_bad, { return resolve("/by-tth/nope") == FS_NODE_NONE; });
+
+/* Path traversal: FUSE normalises, but this is the boundary and it does not
+   get to rely on that. */
+EXO_TEST(fuse_nodes_dotdot, { return resolve("/users/../etc") == FS_NODE_NONE; });
+EXO_TEST(fuse_nodes_dot, { return resolve("/hub/./name") == FS_NODE_NONE; });
+EXO_TEST(fuse_nodes_empty_component, { return resolve("//hub") == FS_NODE_NONE; });
+EXO_TEST(fuse_nodes_embedded_empty, { return resolve("/hub//name") == FS_NODE_NONE; });
+EXO_TEST(fuse_nodes_files_dotdot, {
+	return resolve("/users/" CID_A "/files/../../../etc/passwd") == FS_NODE_NONE;
+});
+EXO_TEST(fuse_nodes_files_empty_component, {
+	return resolve("/users/" CID_A "/files/a//b") == FS_NODE_NONE;
+});
+
+EXO_TEST(fuse_nodes_field_lookup_missing, {
+	return fs_field_lookup(fs_user_fields, "does_not_exist") == NULL;
+});
+EXO_TEST(fuse_nodes_field_lookup_null, {
+	return fs_field_lookup(fs_user_fields, NULL) == NULL;
+});
+
+EXO_TEST(fuse_nodes_hash_ok, { return fs_is_base32_hash(CID_A) == 1; });
+EXO_TEST(fuse_nodes_hash_null, { return fs_is_base32_hash(NULL) == 0; });
+EXO_TEST(fuse_nodes_hash_empty, { return fs_is_base32_hash("") == 0; });
+
+/* -------------------------------------------------------------- nick names */
+
+static char nick[64];
+
+EXO_TEST(fuse_nick_plain, {
+	fs_sanitize_nick("alice", nick, sizeof(nick));
+	return strcmp(nick, "alice") == 0;
+});
+EXO_TEST(fuse_nick_slash, {
+	fs_sanitize_nick("a/b", nick, sizeof(nick));
+	return strcmp(nick, "a_b") == 0;
+});
+EXO_TEST(fuse_nick_control, {
+	fs_sanitize_nick("a\tb\x7f", nick, sizeof(nick));
+	return strcmp(nick, "a_b_") == 0;
+});
+EXO_TEST(fuse_nick_utf8_kept, {
+	fs_sanitize_nick("\xc3\xa5se", nick, sizeof(nick));
+	return strcmp(nick, "\xc3\xa5se") == 0;
+});
+EXO_TEST(fuse_nick_empty, {
+	fs_sanitize_nick("", nick, sizeof(nick));
+	return strcmp(nick, "user") == 0;
+});
+EXO_TEST(fuse_nick_null, {
+	fs_sanitize_nick(NULL, nick, sizeof(nick));
+	return strcmp(nick, "user") == 0;
+});
+EXO_TEST(fuse_nick_dot, {
+	fs_sanitize_nick(".", nick, sizeof(nick));
+	return strcmp(nick, "user") == 0;
+});
+EXO_TEST(fuse_nick_dotdot, {
+	fs_sanitize_nick("..", nick, sizeof(nick));
+	return strcmp(nick, "user") == 0;
+});
+EXO_TEST(fuse_nick_truncates, {
+	char small[4];
+	size_t n = fs_sanitize_nick("abcdefgh", small, sizeof(small));
+	return n == 3 && strcmp(small, "abc") == 0;
+});
+EXO_TEST(fuse_nick_zero_size, {
+	return fs_sanitize_nick("alice", nick, 0) == 0;
+});

--- a/autotest/test_fuse_render.tcc
+++ b/autotest/test_fuse_render.tcc
@@ -1,0 +1,169 @@
+#include "system.h"
+#include "util/memory.h"
+#include "adc/message.h"
+#include "fuse/nodes.h"
+#include "fuse/render.h"
+
+#define CID_A "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+static struct adc_message* inf = NULL;
+static struct adc_message* bare = NULL;
+static struct fs_render_ctx ctx;
+static char buf[8192];
+
+/* Render <path> and compare the bytes with <expect>. */
+static int render_is(const char* path, const char* expect)
+{
+	struct fs_node node;
+	ssize_t len;
+
+	if (!fs_node_resolve(path, &node))
+		return 0;
+
+	len = fs_render(&node, &ctx, buf, sizeof(buf));
+	if (len < 0 || (size_t) len >= sizeof(buf))
+		return 0;
+
+	buf[len] = '\0';
+	return strcmp(buf, expect) == 0;
+}
+
+EXO_TEST(fuse_render_setup, {
+	/* NIJan\sVidar exercises the unescaping: a nick may contain a space. */
+	const char* line = "BINF AAAB ID" CID_A " NIJan\\sVidar DEon\\sholiday SS1024 SF7 SL3"
+	                   " APuhub VE0.8.0 CT2 SUTCP4,ADCS I4192.0.2.10\n";
+	inf = adc_msg_parse(line, strlen(line));
+
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.inf = inf;
+	ctx.sid = 1;
+	ctx.since = 1600000000;
+	ctx.hub_name = "Test hub";
+	ctx.hub_description = "a hub";
+	ctx.hub_version = "uhub/0.8.0";
+	ctx.hub_address = "adcs://localhost:1511";
+	ctx.hub_support = "ADBASE ADTIGR";
+	ctx.hub_users = 42;
+	ctx.my_sid = 1;
+	ctx.my_nick = "tester";
+	ctx.my_cid = CID_A;
+	ctx.my_support = "ADBASE";
+	return inf != NULL;
+});
+
+EXO_TEST(fuse_render_nick_unescaped, { return render_is("/users/" CID_A "/nick", "Jan Vidar\n"); });
+EXO_TEST(fuse_render_description, { return render_is("/users/" CID_A "/description", "on holiday\n"); });
+EXO_TEST(fuse_render_share_size, { return render_is("/users/" CID_A "/share_size", "1024\n"); });
+EXO_TEST(fuse_render_shared_files, { return render_is("/users/" CID_A "/shared_files", "7\n"); });
+EXO_TEST(fuse_render_slots, { return render_is("/users/" CID_A "/slots", "3\n"); });
+EXO_TEST(fuse_render_user_agent, { return render_is("/users/" CID_A "/user_agent", "uhub\n"); });
+EXO_TEST(fuse_render_version, { return render_is("/users/" CID_A "/version", "0.8.0\n"); });
+EXO_TEST(fuse_render_client_type, { return render_is("/users/" CID_A "/client_type", "2\n"); });
+EXO_TEST(fuse_render_support, { return render_is("/users/" CID_A "/support", "TCP4,ADCS\n"); });
+EXO_TEST(fuse_render_ip, { return render_is("/users/" CID_A "/ip", "192.0.2.10\n"); });
+EXO_TEST(fuse_render_sid, { return render_is("/users/" CID_A "/sid", "AAAB\n"); });
+EXO_TEST(fuse_render_connected, { return render_is("/users/" CID_A "/connected", "2020-09-13T12:26:40Z\n"); });
+
+/* The raw line, escapes and all, so a reader can get at fields this mount
+   does not model. */
+EXO_TEST(fuse_render_inf_verbatim, {
+	return render_is("/users/" CID_A "/inf",
+		"BINF AAAB ID" CID_A " NIJan\\sVidar DEon\\sholiday SS1024 SF7 SL3"
+		" APuhub VE0.8.0 CT2 SUTCP4,ADCS I4192.0.2.10\n");
+});
+
+/* An absent text field is an empty file; an absent number is zero. */
+EXO_TEST(fuse_render_absent_setup, {
+	const char* line = "BINF AAAB ID" CID_A "\n";
+	bare = adc_msg_parse(line, strlen(line));
+
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.inf = bare;
+	return bare != NULL;
+});
+
+EXO_TEST(fuse_render_absent_text, { return render_is("/users/" CID_A "/description", ""); });
+EXO_TEST(fuse_render_absent_numeric, { return render_is("/users/" CID_A "/share_size", "0\n"); });
+EXO_TEST(fuse_render_absent_ip, { return render_is("/users/" CID_A "/ip", ""); });
+
+EXO_TEST(fuse_render_no_inf, {
+	memset(&ctx, 0, sizeof(ctx));
+	return render_is("/users/" CID_A "/nick", "") && render_is("/users/" CID_A "/inf", "");
+});
+
+/* ------------------------------------------------------------------- hub/ */
+
+EXO_TEST(fuse_render_hub_reset, {
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.hub_name = "Test hub";
+	ctx.hub_description = "a hub";
+	ctx.hub_version = "uhub/0.8.0";
+	ctx.hub_address = "adcs://localhost:1511";
+	ctx.hub_support = "ADBASE ADTIGR";
+	ctx.hub_users = 42;
+	ctx.my_sid = 1;
+	ctx.my_nick = "tester";
+	ctx.my_cid = CID_A;
+	ctx.my_support = "ADBASE";
+	return 1;
+});
+
+EXO_TEST(fuse_render_hub_state_absent, { return render_is("/hub/state", ""); });
+
+EXO_TEST(fuse_render_hub_state, {
+	ctx.hub_state = "online";
+	return render_is("/hub/state", "online\n");
+});
+
+EXO_TEST(fuse_render_hub_name, { return render_is("/hub/name", "Test hub\n"); });
+EXO_TEST(fuse_render_hub_users, { return render_is("/hub/users", "42\n"); });
+EXO_TEST(fuse_render_hub_address, { return render_is("/hub/address", "adcs://localhost:1511\n"); });
+EXO_TEST(fuse_render_hub_sid, { return render_is("/hub/sid", "AAAB\n"); });
+EXO_TEST(fuse_render_hub_tls_off, { return render_is("/hub/tls", "no\n"); });
+
+EXO_TEST(fuse_render_hub_tls_on, {
+	ctx.tls_version = "TLSv1.3";
+	ctx.tls_cipher = "TLS_AES_256_GCM_SHA384";
+	return render_is("/hub/tls", "TLSv1.3 TLS_AES_256_GCM_SHA384\n");
+});
+
+EXO_TEST(fuse_render_me_nick, { return render_is("/me/nick", "tester\n"); });
+EXO_TEST(fuse_render_me_cid, { return render_is("/me/cid", CID_A "\n"); });
+
+/* ------------------------------------------------------- buffer and errors */
+
+EXO_TEST(fuse_render_measures, {
+	struct fs_node node;
+	fs_node_resolve("/hub/name", &node);
+	/* Nothing is written when it does not fit, but the length is still right. */
+	return fs_render(&node, &ctx, NULL, 0) == 9;
+});
+
+EXO_TEST(fuse_render_short_buffer, {
+	struct fs_node node;
+	char small[4];
+	memset(small, 'x', sizeof(small));
+	fs_node_resolve("/hub/name", &node);
+	return fs_render(&node, &ctx, small, sizeof(small)) == 9 && small[0] == 'x';
+});
+
+EXO_TEST(fuse_render_directory_is_not_a_file, {
+	struct fs_node node;
+	fs_node_resolve("/hub", &node);
+	return fs_render(&node, &ctx, buf, sizeof(buf)) == -1;
+});
+
+EXO_TEST(fuse_render_null_node, { return fs_render(NULL, &ctx, buf, sizeof(buf)) == -1; });
+
+EXO_TEST(fuse_render_timestamp_short_buffer, {
+	char small[4];
+	return fs_render_timestamp(0, small, sizeof(small)) == 0;
+});
+
+EXO_TEST(fuse_render_teardown, {
+	adc_msg_free(inf);
+	adc_msg_free(bare);
+	inf = NULL;
+	bare = NULL;
+	return 1;
+});

--- a/autotest/test_fuse_roster.tcc
+++ b/autotest/test_fuse_roster.tcc
@@ -1,0 +1,212 @@
+#include "system.h"
+#include "util/memory.h"
+#include "adc/message.h"
+#include "fuse/roster.h"
+
+#define CID_A "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+#define CID_B "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+
+static struct fs_roster* roster = NULL;
+
+/* SID "AAAB" is 1, "AAAC" is 2 -- see sid_to_string(). */
+#define INF_A  "BINF AAAB ID" CID_A " NIalice DEhello SS1024 SL3 I4127.0.0.1\n"
+#define INF_B  "BINF AAAC ID" CID_B " NIbob I4127.0.0.2\n"
+
+static struct adc_message* parse(const char* line)
+{
+	return adc_msg_parse(line, strlen(line));
+}
+
+/* Feed one line into the roster and drop our reference to it. */
+static enum fs_roster_result feed(const char* line, time_t now)
+{
+	enum fs_roster_result result;
+	struct adc_message* msg = parse(line);
+	if (!msg)
+		return FS_ROSTER_REJECTED;
+
+	result = fs_roster_update(roster, msg, now);
+	adc_msg_free(msg);
+	return result;
+}
+
+EXO_TEST(fuse_roster_create, {
+	roster = fs_roster_create();
+	return roster != NULL && fs_roster_size(roster) == 0;
+});
+
+EXO_TEST(fuse_roster_add, { return feed(INF_A, 1000) == FS_ROSTER_ADDED; });
+EXO_TEST(fuse_roster_size_1, { return fs_roster_size(roster) == 1; });
+
+EXO_TEST(fuse_roster_by_cid, {
+	struct fs_roster_user* user = fs_roster_by_cid(roster, CID_A);
+	return user && user->sid == 1 && user->since == 1000;
+});
+
+EXO_TEST(fuse_roster_by_sid, {
+	struct fs_roster_user* user = fs_roster_by_sid(roster, 1);
+	return user && strcmp(user->cid, CID_A) == 0;
+});
+
+EXO_TEST(fuse_roster_by_sid_missing, { return fs_roster_by_sid(roster, 4711) == NULL; });
+EXO_TEST(fuse_roster_by_sid_zero, { return fs_roster_by_sid(roster, 0) == NULL; });
+EXO_TEST(fuse_roster_by_cid_missing, { return fs_roster_by_cid(roster, CID_B) == NULL; });
+EXO_TEST(fuse_roster_by_cid_null, { return fs_roster_by_cid(roster, NULL) == NULL; });
+
+EXO_TEST(fuse_roster_nick, {
+	char nick[64];
+	struct fs_roster_user* user = fs_roster_by_cid(roster, CID_A);
+	return fs_roster_nick(user, nick, sizeof(nick)) == 5 && strcmp(nick, "alice") == 0;
+});
+
+EXO_TEST(fuse_roster_by_nick, {
+	return fs_roster_by_nick(roster, "alice") == fs_roster_by_cid(roster, CID_A);
+});
+
+EXO_TEST(fuse_roster_by_nick_missing, { return fs_roster_by_nick(roster, "nobody") == NULL; });
+
+EXO_TEST(fuse_roster_add_second, { return feed(INF_B, 1001) == FS_ROSTER_ADDED; });
+EXO_TEST(fuse_roster_size_2, { return fs_roster_size(roster) == 2; });
+
+/* An INF update names only what changed; everything else must survive it. */
+EXO_TEST(fuse_roster_merge, { return feed("BINF AAAB DEbusy\n", 2000) == FS_ROSTER_UPDATED; });
+
+EXO_TEST(fuse_roster_merge_replaced, {
+	struct fs_roster_user* user = fs_roster_by_cid(roster, CID_A);
+	char* value = adc_msg_get_named_argument(user->inf, "DE");
+	int ok = value && strcmp(value, "busy") == 0;
+	hub_free(value);
+	return ok;
+});
+
+EXO_TEST(fuse_roster_merge_kept_nick, {
+	struct fs_roster_user* user = fs_roster_by_cid(roster, CID_A);
+	char* value = adc_msg_get_named_argument(user->inf, "NI");
+	int ok = value && strcmp(value, "alice") == 0;
+	hub_free(value);
+	return ok;
+});
+
+EXO_TEST(fuse_roster_merge_kept_share, {
+	struct fs_roster_user* user = fs_roster_by_cid(roster, CID_A);
+	char* value = adc_msg_get_named_argument(user->inf, "SS");
+	int ok = value && strcmp(value, "1024") == 0;
+	hub_free(value);
+	return ok;
+});
+
+EXO_TEST(fuse_roster_merge_kept_since, {
+	struct fs_roster_user* user = fs_roster_by_cid(roster, CID_A);
+	return user->since == 1000;
+});
+
+EXO_TEST(fuse_roster_merge_no_new_user, { return fs_roster_size(roster) == 2; });
+
+/* An INF with no source SID belongs to nobody. */
+EXO_TEST(fuse_roster_no_sid, {
+	struct adc_message* msg = adc_msg_create("BINF ID" CID_A " NIx\n");
+	enum fs_roster_result result = fs_roster_update(roster, msg, 3000);
+	adc_msg_free(msg);
+	return result == FS_ROSTER_REJECTED;
+});
+
+/* A first INF with no CID has no path to live at. */
+EXO_TEST(fuse_roster_no_cid, { return feed("BINF AAAD NIcarol\n", 3000) == FS_ROSTER_REJECTED; });
+EXO_TEST(fuse_roster_no_cid_not_added, { return fs_roster_size(roster) == 2; });
+
+EXO_TEST(fuse_roster_bad_cid, { return feed("BINF AAAD IDnope NIcarol\n", 3000) == FS_ROSTER_REJECTED; });
+
+EXO_TEST(fuse_roster_null_message, {
+	return fs_roster_update(roster, NULL, 3000) == FS_ROSTER_REJECTED;
+});
+
+/* Ordered by CID, which is what users/ lists. */
+EXO_TEST(fuse_roster_iterate, {
+	struct fs_roster_user* first = fs_roster_first(roster);
+	struct fs_roster_user* second = fs_roster_next(roster);
+	struct fs_roster_user* third = fs_roster_next(roster);
+	return first && second && !third
+		&& strcmp(first->cid, CID_A) == 0
+		&& strcmp(second->cid, CID_B) == 0;
+});
+
+/* A CID that reappears on a new SID is the same person reconnecting; the stale
+   entry must not keep the name. */
+EXO_TEST(fuse_roster_cid_reused, {
+	return feed("BINF AAAE ID" CID_A " NIalice\n", 4000) == FS_ROSTER_ADDED;
+});
+EXO_TEST(fuse_roster_cid_reused_size, { return fs_roster_size(roster) == 2; });
+EXO_TEST(fuse_roster_cid_reused_new_sid, {
+	struct fs_roster_user* user = fs_roster_by_cid(roster, CID_A);
+	return user && user->sid == 4 && user->since == 4000;
+});
+EXO_TEST(fuse_roster_cid_reused_old_sid_gone, { return fs_roster_by_sid(roster, 1) == NULL; });
+
+EXO_TEST(fuse_roster_remove, { return fs_roster_remove(roster, 4) == 1; });
+EXO_TEST(fuse_roster_remove_again, { return fs_roster_remove(roster, 4) == 0; });
+EXO_TEST(fuse_roster_remove_size, { return fs_roster_size(roster) == 1; });
+EXO_TEST(fuse_roster_remove_cid_gone, { return fs_roster_by_cid(roster, CID_A) == NULL; });
+
+EXO_TEST(fuse_roster_clear, {
+	fs_roster_clear(roster);
+	return fs_roster_size(roster) == 0 && fs_roster_first(roster) == NULL;
+});
+
+EXO_TEST(fuse_roster_reuse_after_clear, {
+	return feed(INF_A, 5000) == FS_ROSTER_ADDED && fs_roster_size(roster) == 1;
+});
+
+/*
+ * A walk that stops at the first match must still leave the tree walkable and
+ * destroyable. The iterator lives inside the tree and rb_tree_destroy()
+ * refuses a stack that was left loaded, so an abandoned walk shows up as a
+ * crash at unmount rather than here -- which is why this is a test.
+ */
+EXO_TEST(fuse_roster_walk_stopped_early_can_be_destroyed, {
+	struct fs_roster* other = fs_roster_create();
+	struct adc_message* msg;
+	char line[256];
+	char cid[MAX_CID_LEN + 1];
+	int i;
+	int ok;
+
+	/*
+	 * Enough users that the tree has depth, and a match that is not the
+	 * leftmost one: stopping on the very first entry leaves nothing on the
+	 * iterator's stack and would not reproduce anything.
+	 */
+	for (i = 0; i < 16; i++)
+	{
+		memset(cid, 'A' + i, MAX_CID_LEN);
+		cid[MAX_CID_LEN] = '\0';
+
+		snprintf(line, sizeof(line), "BINF AA%c%c ID%s NIuser%d\n",
+			'A' + (i / 8), 'B' + (i % 8), cid, i);
+
+		msg = parse(line);
+		fs_roster_update(other, msg, 1000);
+		adc_msg_free(msg);
+	}
+
+	ok = (fs_roster_size(other) == 16);
+
+	/* Somewhere in the middle, so the walk is abandoned part-way down. */
+	ok = ok && (fs_roster_by_nick(other, "user9") != NULL);
+
+	/* The tree must still be walkable afterwards. */
+	ok = ok && (fs_roster_first(other) != NULL);
+
+	fs_roster_destroy(other);   /* aborts if a walk was left in progress */
+	return ok;
+});
+
+EXO_TEST(fuse_roster_destroy, {
+	fs_roster_destroy(roster);
+	roster = NULL;
+	return 1;
+});
+
+EXO_TEST(fuse_roster_destroy_null, {
+	fs_roster_destroy(NULL);
+	return 1;
+});

--- a/autotest/test_seedcc.tcc
+++ b/autotest/test_seedcc.tcc
@@ -63,6 +63,110 @@ static enum seed_cc_type scc_type(const char* line)
 	return scc_req.type;
 }
 
+/* --- named identifiers, for a download asked for by name ------------------ */
+
+/*
+ * A file list has no hash until it has been received, so it is asked for by
+ * name. The parser therefore understands both forms and says which one it saw:
+ * a TTH lands in .tth and a name lands in .name, never both.
+ */
+
+/* A CGET is a peer asking us to serve, and we serve by hash: a name there is
+   not a request we can answer, and never becomes one. */
+EXO_TEST(seedcc_parse_get_refuses_a_name, {
+	return scc_type("CGET file files.xml.bz2 0 -1\n") == SEED_CC_UNSUPPORTED;
+});
+
+EXO_TEST(seedcc_parse_snd_named_identifier, {
+	return scc_type("CSND file files.xml.bz2 0 4096\n") == SEED_CC_SND
+		&& strcmp(scc_req.name, "files.xml.bz2") == 0
+		&& scc_req.tth[0] == '\0';
+});
+
+EXO_TEST(seedcc_parse_get_tth_leaves_name_empty, {
+	return scc_type("CGET file TTH/" SCC_TTH " 0 -1\n") == SEED_CC_GET_FILE
+		&& strcmp(scc_req.tth, SCC_TTH) == 0
+		&& scc_req.name[0] == '\0';
+});
+
+/* A name is a name, not a path: a peer must not be able to spell a directory,
+   let alone one above the share. */
+EXO_TEST(seedcc_parse_named_rejects_path, {
+	return scc_type("CSND file dir/files.xml.bz2 0 10\n") == SEED_CC_UNSUPPORTED;
+});
+
+EXO_TEST(seedcc_parse_named_rejects_traversal, {
+	return scc_type("CSND file ../../etc/passwd 0 10\n") == SEED_CC_UNSUPPORTED;
+});
+
+EXO_TEST(seedcc_parse_named_rejects_absolute, {
+	return scc_type("CSND file /etc/passwd 0 10\n") == SEED_CC_UNSUPPORTED;
+});
+
+EXO_TEST(seedcc_parse_named_rejects_oversized, {
+	char line[256];
+	char name[SEED_GRANT_FILENAME_MAX + 8];
+	memset(name, 'a', sizeof(name) - 1);
+	name[sizeof(name) - 1] = '\0';
+	snprintf(line, sizeof(line), "CSND file %s 0 10\n", name);
+	return scc_type(line) == SEED_CC_UNSUPPORTED;
+});
+
+/* A malformed TTH stays malformed: "TTH/" is a prefix the parser commits to,
+   so a bad hash after it is not silently reinterpreted as a file name. */
+EXO_TEST(seedcc_parse_named_does_not_rescue_a_bad_tth, {
+	return scc_type("CSND file TTH/not-a-hash 0 10\n") == SEED_CC_UNSUPPORTED;
+});
+
+/* CGFI asks about content, which is addressed by hash and nothing else. */
+EXO_TEST(seedcc_parse_gfi_refuses_a_name, {
+	return scc_type("CGFI file files.xml.bz2\n") == SEED_CC_UNSUPPORTED;
+});
+
+/* --- grants for a named download ----------------------------------------- */
+
+EXO_TEST(seedcc_grant_filelist, {
+	struct seed_grants* grants = seed_grants_create();
+	struct seed_grant grant;
+	int ok = seed_grant_issue_filelist(grants, SCC_TOKEN, SCC_CID, "files.xml.bz2", 1000)
+		&& seed_grant_is_download(grants, SCC_TOKEN, 1000, &grant)
+		&& strcmp(grant.filename, "files.xml.bz2") == 0
+		&& grant.tth[0] == '\0';
+	seed_grants_destroy(grants);
+	return ok;
+});
+
+EXO_TEST(seedcc_grant_filelist_refuses_a_path, {
+	struct seed_grants* grants = seed_grants_create();
+	int ok = !seed_grant_issue_filelist(grants, SCC_TOKEN, SCC_CID, "../etc/passwd", 1000);
+	seed_grants_destroy(grants);
+	return ok;
+});
+
+EXO_TEST(seedcc_grant_filelist_refuses_a_space, {
+	struct seed_grants* grants = seed_grants_create();
+	int ok = !seed_grant_issue_filelist(grants, SCC_TOKEN, SCC_CID, "two words", 1000);
+	seed_grants_destroy(grants);
+	return ok;
+});
+
+EXO_TEST(seedcc_grant_filelist_refuses_empty, {
+	struct seed_grants* grants = seed_grants_create();
+	int ok = !seed_grant_issue_filelist(grants, SCC_TOKEN, SCC_CID, "", 1000)
+	      && !seed_grant_issue_filelist(grants, SCC_TOKEN, SCC_CID, NULL, 1000);
+	seed_grants_destroy(grants);
+	return ok;
+});
+
+/* An ordinary download grant still has to name a hash. */
+EXO_TEST(seedcc_grant_download_still_requires_a_tth, {
+	struct seed_grants* grants = seed_grants_create();
+	int ok = !seed_grant_issue_download(grants, SCC_TOKEN, SCC_CID, NULL, 0, NULL, 1000)
+	      && !seed_grant_issue_download(grants, SCC_TOKEN, SCC_CID, "nope", 0, NULL, 1000);
+	seed_grants_destroy(grants);
+	return ok;
+});
+
 /* --- the constants the protocol depends on ------------------------------- */
 
 EXO_TEST(seedcc_tth_constants_are_well_formed, {

--- a/build.zig
+++ b/build.zig
@@ -400,6 +400,11 @@ pub fn build(b: *std.Build) void {
     if (!release) flags.append("-DDEBUG") catch @panic("OOM");
     if (lowlevel_debug) flags.append("-DLOWLEVEL_DEBUG") catch @panic("OOM");
     if (systemd) flags.append("-DSYSTEMD") catch @panic("OOM");
+    // fuse/filelist.c decompresses a peer's file list with libbz2. Its parser
+    // needs no library and is built and tested regardless; the decompressor
+    // stubs itself out without this, so a tests-only build -- and Windows --
+    // needs no bzip2 at all.
+    if (fuse) flags.append("-DHAVE_BZLIB") catch @panic("OOM");
     if (target.result.cpu.arch.endian() == .big) flags.append("-DARCH_BIGENDIAN") catch @panic("OOM");
     const cflags = flags.toOwnedSlice() catch @panic("OOM");
 
@@ -530,8 +535,11 @@ pub fn build(b: *std.Build) void {
         ctx.addSources(autotest_mod, &seeder_sources);
         ctx.addSources(autotest_mod, &seeder_daemon_sources);
         ctx.addSources(autotest_mod, &fuse_sources);
-        // fuse/filelist.c is compiled into the tests, and it uses bzlib.
-        autotest_mod.linkSystemLibrary("bz2", .{});
+        // fuse/filelist.c is compiled into the tests. Its parser needs no
+        // library; its decompressor does, and stubs itself out without one, so
+        // libbz2 is linked only where it was asked for -- a tests-only build,
+        // and Windows, must not need it.
+        if (fuse) autotest_mod.linkSystemLibrary("bz2", .{});
         // hubconn.c is built on the ADC client; ioqueue.c already comes in via
         // core_sources, so only adcclient.c is added here.
         ctx.addSources(autotest_mod, &.{"src/tools/adcclient.c"});

--- a/build.zig
+++ b/build.zig
@@ -100,6 +100,28 @@ const seeder_daemon_sources = [_][]const u8{
     "src/seeder/ingest.c",
 };
 
+// uhub-fuse. fs.c and main.c are the only files that include <fuse.h>, so the
+// rest builds into autotest-bin on a machine with no libfuse at all -- which is
+// where the path, roster and rendering logic is tested. Mirrors fuse_SOURCES /
+// fuse_test_SOURCES in CMakeLists.txt.
+const fuse_sources = [_][]const u8{
+    "src/fuse/bridge.c",
+    "src/fuse/chatlog.c",
+    "src/fuse/config.c",
+    "src/fuse/filelist.c",
+    "src/fuse/nodes.c",
+    "src/fuse/render.c",
+    "src/fuse/roster.c",
+    "src/fuse/session.c",
+    "src/fuse/stream.c",
+    "src/fuse/transfer.c",
+};
+
+const fuse_daemon_sources = [_][]const u8{
+    "src/fuse/fs.c",
+    "src/fuse/main.c",
+};
+
 // autotest/test_*.tcc sources, sorted, mirroring the `file(GLOB ...)` +
 // `list(SORT ...)` in CMakeLists.txt. Kept as an explicit list (like the C
 // source sets above) rather than globbed at build time; add a new .tcc here.
@@ -115,6 +137,12 @@ const tcc_sources = [_][]const u8{
     "test_connect.tcc",
     "test_credentials.tcc",
     "test_eventqueue.tcc",
+    "test_fuse_chatlog.tcc",
+    "test_fuse_config.tcc",
+    "test_fuse_filelist.tcc",
+    "test_fuse_nodes.tcc",
+    "test_fuse_render.tcc",
+    "test_fuse_roster.tcc",
     "test_hbri.tcc",
     "test_help_rtf0.tcc",
     "test_hub.tcc",
@@ -308,6 +336,7 @@ pub fn build(b: *std.Build) void {
     const release = b.option(bool, "release", "Release build; disables the DEBUG define when on") orelse true;
     const systemd = b.option(bool, "systemd", "Enable systemd notify and journal logging") orelse false;
     const adc_stress = b.option(bool, "adc-stress", "Build the adcrush stress-tester client") orelse false;
+    const fuse = b.option(bool, "fuse", "Build uhub-fuse, the filesystem client (needs libfuse3)") orelse false;
     const lowlevel_debug = b.option(bool, "lowlevel-debug", "Enable low level debug messages") orelse false;
     const javascript = b.option(bool, "javascript", "Build the mod_javascript plugin (embeds QuickJS, a git submodule)") orelse false;
     // TLS is mandatory. By default we build the bundled LibreSSL (a zig
@@ -500,6 +529,9 @@ pub fn build(b: *std.Build) void {
         ctx.addSources(autotest_mod, &core_sources);
         ctx.addSources(autotest_mod, &seeder_sources);
         ctx.addSources(autotest_mod, &seeder_daemon_sources);
+        ctx.addSources(autotest_mod, &fuse_sources);
+        // fuse/filelist.c is compiled into the tests, and it uses bzlib.
+        autotest_mod.linkSystemLibrary("bz2", .{});
         // hubconn.c is built on the ADC client; ioqueue.c already comes in via
         // core_sources, so only adcclient.c is added here.
         ctx.addSources(autotest_mod, &.{"src/tools/adcclient.c"});
@@ -541,6 +573,34 @@ pub fn build(b: *std.Build) void {
         const admin = b.addExecutable(.{ .name = "uhub-admin", .root_module = admin_mod });
         admin.pie = true;
         b.installArtifact(admin);
+
+        if (fuse) {
+            const fuse_mod = ctx.module();
+            ctx.addSources(fuse_mod, &fuse_sources);
+            ctx.addSources(fuse_mod, &fuse_daemon_sources);
+            // The transfer half is uhub-seeder's, driven rather than
+            // reimplemented; mirrors fuse_seeder_SOURCES in CMakeLists.txt.
+            ctx.addSources(fuse_mod, &.{
+                "src/seeder/cache.c",
+                "src/seeder/cc.c",
+                "src/seeder/grant.c",
+                "src/seeder/sniff.c",
+                "src/tools/adcclient.c",
+                "src/core/ioqueue.c",
+            });
+            ctx.addSqlite(fuse_mod);
+            fuse_mod.linkLibrary(common);
+            ctx.linkExternal(fuse_mod);
+            // No pkg-config here, unlike CMake: name the library and let the
+            // linker find it. The headers live in a subdirectory of their own.
+            fuse_mod.addIncludePath(.{ .cwd_relative = "/usr/include/fuse3" });
+            fuse_mod.linkSystemLibrary("fuse3", .{});
+            // A peer's share is browsed by reading its bzip2'd file list.
+            fuse_mod.linkSystemLibrary("bz2", .{});
+            const fuse_exe = b.addExecutable(.{ .name = "uhub-fuse", .root_module = fuse_mod });
+            fuse_exe.pie = true;
+            b.installArtifact(fuse_exe);
+        }
 
         if (adc_stress) {
             const adcrush_mod = ctx.module();

--- a/doc/fuse.txt
+++ b/doc/fuse.txt
@@ -1,0 +1,291 @@
+Mounting a hub
+--------------
+
+uhub-fuse mounts an ADC hub as a directory. The hub becomes a filesystem: who
+is online is a directory listing, what a user advertises is a file you can cat,
+and anything that reads files can read the hub -- ls, grep, find, a shell loop,
+a monitoring script that wants a number without speaking a protocol.
+
+It is not part of the hub and needs no support from it. It logs in as an
+ordinary client, over the same port and the same protocol as everybody else,
+and appears in the user list like anyone else.
+
+See uhub-fuse(1) for the command line, and getstarted.txt for the hub itself.
+
+
+1. What it looks like
+---------------------
+
+    /mnt/hub/
+      hub/          what the hub says about itself
+        state         offline, connecting, online or failed
+        name          the hub's name
+        description   its description, which is also its topic
+        version       the software it runs
+        address       the URL this mount was pointed at
+        support       the extensions it announced
+        users         how many are online
+        sid           our session id
+        tls           the TLS version and cipher, or "no"
+      me/           nick, cid, sid, support -- the mount's own identity
+      chat/
+        main          the hub's chat: read it, tail it, write to it
+        private       what was said to you, and what you said to somebody
+      users/
+        <CID>/      one directory per user, named by their CID
+          nick description share_size shared_files slots ip
+          user_agent version client_type support sid connected
+          inf         the raw INF line, verbatim
+          msg         write-only: sends a private message
+          files/      what that user is sharing
+      by-nick/
+        <nick>      a symlink to ../users/<CID>
+      by-tth/
+        <TTH>       any file on the hub, by hash
+
+A CID is 39 base32 characters, which makes it usable as a directory name
+without escaping anything: the alphabet has no slash, no NUL and no dot, so a
+CID can never spell "." or "..". It is also the only name a user has that is
+stable -- a nick can be changed, and is not unique across a reconnect.
+
+Everything is read-only. There is nothing to sync, nothing is cached to disk,
+and unmounting leaves nothing behind.
+
+
+2. Reading it
+-------------
+
+    $ uhub-fuse --hub=adc://hub.example.org:1511 /mnt/hub
+
+    $ cat /mnt/hub/hub/users
+    42
+
+    $ ls /mnt/hub/by-nick
+    alice   bob   carol
+
+    $ cat /mnt/hub/by-nick/alice/share_size
+    1099511627776
+
+    # everyone sharing nothing:
+    $ for u in /mnt/hub/users/*/; do
+    >     [ "$(cat "$u/share_size")" = 0 ] && cat "$u/nick"
+    > done
+
+    # the fields this mount does not model are still there:
+    $ grep -o 'EM[^ ]*' /mnt/hub/by-nick/alice/inf
+
+A file holds one value and a trailing newline, so no parser is needed. A field
+the user did not advertise is an empty file; a numeric one that was not
+advertised reads as 0, because that is what every client that omits it means.
+
+users/<cid>/inf is the line the hub sent, escapes and all. It is there for the
+fields this mount has no name for -- the ADC INF grammar grows with every
+extension, and a mount that only showed what it knew about would quietly hide
+the rest.
+
+
+3. Chat
+-------
+
+chat/main is the hub's main chat. Reading it gives the recent history; writing
+to it says something:
+
+    $ tail -f /mnt/hub/chat/main
+    2026-08-21T00:27:44Z -- connected to adc://hub.example.org:1511
+    2026-08-21T00:28:02Z <alice> anyone got the new release?
+    2026-08-21T00:28:19Z * bob waves
+
+    $ echo "over here" > /mnt/hub/chat/main
+
+One line per message: a timestamp, who said it, and what they said. An action
+("/me waves") is marked with a star instead of angle brackets. Lines beginning
+with "--" are the connection itself rather than anything anyone said, so that
+a quiet hub can be told apart from one that is not there any more.
+
+A newline ends a message, so a single write can say several things and a write
+with no newline in it is said when the file is closed -- `echo -n` works, and
+so does a program writing in chunks. A message longer than 1024 bytes is
+refused with EMSGSIZE rather than truncated.
+
+Private messages have their own file, because they are not part of the room:
+
+    $ echo "on my way" > /mnt/hub/users/<CID>/msg
+    $ cat /mnt/hub/chat/private
+    2026-08-21T00:29:03Z <alice> where are you?
+    2026-08-21T00:29:31Z -> <alice> on my way
+
+users/<CID>/msg is write-only -- there is no such thing as reading a message
+you have not sent. Outgoing messages are written to chat/private by the mount
+itself, since a hub delivers a private message to its recipient and not back to
+its sender; without that, chat/private would hold one half of every
+conversation.
+
+chat/main and chat/private are streams, not snapshots: their size is how much
+has ever been said, and a reader picks up where it left off. Only the most
+recent 256 KB is kept -- a reader that falls further behind than that is given
+the oldest bytes still held rather than an error.
+
+
+4. Files
+--------
+
+users/<CID>/files/ is what that user is sharing, as a directory tree:
+
+    $ ls /mnt/hub/by-nick/alice/files/
+    Music  Photos  incoming
+
+    $ cat /mnt/hub/by-nick/alice/files/Music/song.flac > song.flac
+
+The listing comes from that user's file list -- the XML document every DC
+client publishes as "files.xml.bz2" -- which is fetched the first time the
+directory is listed and kept for five minutes. Stat'ing files/ does not fetch
+one, so "ls -l users/" over a busy hub does not start a download per user.
+
+by-tth/<hash> is the same thing without a name: any file on the hub, addressed
+by its tiger tree hash, wherever it is. The directory has no listing -- there
+is no set of hashes to enumerate, only the one you already know -- and reading
+one asks the hub who has it.
+
+    $ cat /mnt/hub/by-tth/AI3IWQOWFWVLPBKQ3JMOQJVUVKUFZLKA3TFXKHY > file
+
+Where the bytes come from:
+
+  * A file in somebody's share is asked of that somebody. We know whose share
+    it is, so there is nothing to search for.
+  * A hash under by-tth is searched for on the hub, and asked of whoever
+    answers.
+
+Either way the mount is the one listening and the peer dials in, which is what
+makes this work when the peer is passive -- and why uhub-fuse needs a port of
+its own (transfer_port) and says so in its INF.
+
+
+5. What is verified, and what is not
+------------------------------------
+
+A file small enough to hold -- up to max_file_size, 1 GiB by default -- is
+downloaded in one piece, hashed, and kept only if it hashes to the name it was
+asked for. Content that does not is discarded before any reader sees a byte of
+it. That is what makes by-tth trustworthy: the name *is* the checksum.
+
+A file larger than that is read through a sliding window instead: the range a
+reader asked for is requested, plus a little of what it is likely to ask for
+next, and nothing is written to disk. Reading a 20 GB film does not download
+20 GB, and seeking into the middle of one does not download the beginning.
+
+The cost is that such a read cannot be verified. A TTH covers a whole file, and
+the leaf hashes that would let part of one be checked (ADC's "CGET tthl") are
+not implemented on either side of this codebase. So bytes read that way are
+what a peer chose to send, and nothing here can tell you they are what you
+asked for.
+
+That is why the boundary is the size ceiling and not a convenience setting:
+everything that *can* be verified still is, and streaming applies only where
+verification was never available. Raising max_file_size moves more content onto
+the verified path, at the cost of holding it in the cache.
+
+Cached content lives under cache_dir and survives a restart. Streamed content
+is never cached -- storing unverified bytes as though they had been checked
+would be a lie the next reader could not see through.
+
+
+6. Snapshots, and what is live
+------------------------------
+
+A hub changes while you read it. Two rules make that predictable:
+
+  * A metadata file is rendered when it is opened, and reading it returns that snapshot
+    however long the descriptor stays open. A user's INF can be replaced
+    between two reads of one file, and a reader that got the first half of one
+    nick and the second half of another would have no way to notice. Open it
+    again to see the new value.
+
+  * A directory listing is generated when it is read, so it is as current as
+    the moment of the ls.
+
+chat/ is the exception to both: see section 3.
+
+When the hub connection drops, users/ empties and hub/ forgets what the hub
+said about itself. hub/state says what is going on, and hub/address -- which is
+configuration, not something the hub claimed -- stays. A stale user list that
+looks live is worse than an empty one, so there is no last known state to read.
+The mount stays up and keeps answering throughout, and reconnects on its own
+with a widening delay of up to a minute.
+
+The exception is a hub that was pinned with ?kp= and presented a different
+certificate. That is a configuration error or an interception, never a
+transient fault, so it is not retried: hub/state reads "failed" and stays there.
+
+
+7. Connecting to it
+-------------------
+
+    adc://host:port                 plaintext
+    adcs://host:port                TLS, unauthenticated
+    adcs://host:port/?kp=SHA256/... TLS, with the hub's certificate pinned
+
+TLS without a keyprint is encrypted but not authenticated -- an ADC hub's
+certificate is normally self-signed, so there is no CA to check it against.
+Pin the keyprint on any hub where it matters; the hub publishes it in its own
+URL.
+
+    $ uhub-fuse --hub='adcs://hub.example.org:1511/?kp=SHA256/ABC...' \
+        --nick=archivist --config=/etc/uhub/uhub-fuse.conf /mnt/hub
+
+Without --nick the mount logs in as "uhub-fuse". It is a login like any other:
+the hub sees it, counts it, and can ban it.
+
+A password does not belong on the command line -- an argument is in the
+process's argv, which every user on the machine can read out of ps. Put it in a
+configuration file instead, mode 600:
+
+    # /etc/uhub/uhub-fuse.conf
+    hub = adcs://hub.example.org:1511/?kp=SHA256/ABC...
+    nick = archivist
+    password = secret
+
+    $ uhub-fuse --config=/etc/uhub/uhub-fuse.conf /mnt/hub
+
+uhub-fuse says so if that file holds a password and is readable by anyone but
+its owner. Anything given on the command line overrides the file, so one file
+can still be pointed at a different hub for a single run. A value runs to the
+end of its line and is not interpreted further, so a password may contain '#',
+'=' and spaces.
+
+
+8. What is not there yet
+------------------------
+
+  * Partial file lists. A share is fetched as one document, so the first `ls`
+    of a very large share pays for all of it. ADC can ask for one directory at
+    a time ("CGET list /dir/"), which is the shape readdir actually wants.
+  * Leaf hashes, which would let a streamed read be verified. See section 5.
+  * Uploading. The mount shares nothing and answers no searches; it is a
+    reader.
+
+
+9. How it works
+---------------
+
+Two threads. One is uhub's ordinary event loop, and owns the ADC client, the
+roster and everything else; the other is libfuse's. Nothing in the hub half is
+reentrant and none of it is locked, so a filesystem operation does not touch it
+directly: it is packed into a task, handed to the event loop through the same
+self-pipe the DNS resolver uses, and waited for. The answer comes back on the
+same task. src/fuse/bridge.h has the details.
+
+That is also why metadata reads are snapshots. Rendering happens once, on the
+event loop, at open(); after that a read is a memcpy on the FUSE thread and
+never crosses over at all. A chat read does cross over, because the log it
+reads from is being appended to by the event loop as it goes.
+
+A read that has to fetch something is *parked*: the FUSE thread stays blocked
+in the bridge, and the task is completed when the content arrives, when the
+search comes back empty, or when the clock runs out. Nothing else on the mount
+is held up meanwhile -- other threads keep answering -- and a reader that gives
+up (^C) is let go at once rather than held for the rest of the timeout.
+
+The transfer machinery itself is uhub-seeder's, driven rather than
+reimplemented: seeder/cc.c speaks the client-to-client protocol, seeder/cache.c
+stores and verifies, seeder/grant.c decides which connection may do what. See
+seedcache.txt section 5 for that exchange written out.

--- a/doc/uhub-fuse.1
+++ b/doc/uhub-fuse.1
@@ -1,0 +1,193 @@
+.TH UHUB-FUSE 1 "August 2026"
+.\" Please adjust this date whenever revising the manpage.
+.SH NAME
+uhub\-fuse \- mount an ADC hub as a filesystem
+.SH SYNOPSIS
+.B uhub\-fuse
+.BI \-\-hub= URL
+.RI [ options ]
+.I mountpoint
+.SH DESCRIPTION
+uhub\-fuse mounts an ADC hub as a directory. Who is online becomes a directory
+listing, what each user advertises becomes a file, and anything that can read a
+file can read the hub.
+.PP
+It is not part of the hub and needs no support from it. It logs in as an
+ordinary client over the same port and the same protocol as everybody else, and
+appears in the user list like anyone else.
+.PP
+The mount holds
+.B hub/
+(what the hub says about itself, including
+.BR hub/state ),
+.B me/
+(the mount's own identity),
+.BR chat/ ,
+.B users/
+\- one directory per user, named by their CID, holding
+.BR nick ,
+.BR description ,
+.BR share_size ,
+.BR ip ,
+the raw
+.B inf
+line and the rest \- and
+.BR by\-nick/ ,
+which is symlinks into
+.BR users/ .
+.PP
+A CID is used as the directory name because it is the only name a user has that
+is stable, and because its 39 base32 characters are safe in a path.
+.PP
+.B chat/main
+is the hub's chat: reading it gives the recent history, and writing to it says
+something. A newline ends a message, and so does closing the file, so both
+.B echo
+and a program writing in chunks work.
+.B chat/private
+holds what was said to you privately and what you said to somebody, and
+.BI users/ CID /msg
+is write-only and sends one.
+.PP
+.BI users/ CID /files/
+is what that user is sharing, browsable as a directory tree, and
+.BI by\-tth/ TTH
+is any file on the hub addressed by its tiger tree hash. Reading either fetches
+the file from whoever has it over an ordinary client\-to\-client connection, so
+the mount needs a
+.B transfer_port
+that the hub's other users can reach.
+.PP
+A file up to
+.B max_file_size
+is fetched whole, checked against the hash that named it, and kept in
+.BR cache_dir .
+A larger one is read through a sliding window and never stored \- and, because
+a TTH covers a whole file and this build asks for no leaf hashes, never
+verified. See
+.B fuse.txt
+section 5.
+.PP
+Everything else is read-only and unmounting leaves nothing behind. See
+.BR fuse.txt (in the documentation directory)
+for the full layout and for what each file contains.
+.SH OPTIONS
+.TP
+.BI \-\-config= FILE
+Read the settings below from
+.I FILE
+instead of the command line, in the hub's "key = value" format. This is where a
+password belongs: an argument is in the process's argv, which every user on the
+machine can read out of
+.BR ps .
+uhub\-fuse warns if the file holds a password and is readable by anyone but its
+owner. Options given on the command line override the file. See
+.B uhub\-fuse.conf
+for a commented example.
+.TP
+.BI \-\-hub= URL
+The hub to mount:
+.BI adc:// host : port
+for a plaintext connection,
+.BI adcs:// host : port
+for TLS, or
+.BI adcs:// host : port /?kp=SHA256/ base32
+to also pin the hub's certificate. TLS without a keyprint is encrypted but not
+authenticated. Required.
+.TP
+.BI \-\-nick= NAME
+The nick to log in with. Defaults to
+.BR uhub\-fuse .
+.TP
+.BI \-\-password= SECRET
+The password, for a hub where the account is registered. Every user on the
+machine can read this out of
+.BR ps ;
+prefer
+.BR \-\-config .
+.TP
+.B \-f
+Stay in the foreground.
+.TP
+.B \-d
+Foreground, with libfuse's protocol tracing.
+.TP
+.B \-s
+Serve the filesystem from a single thread.
+.TP
+.BI \-o " OPTION" [,...]
+Mount options, passed to libfuse \-\-
+.BR ro ,
+.BR allow_other
+and the rest. See
+.BR mount.fuse3 (8).
+.TP
+.BR \-h ", " \-\-help
+The options above, followed by libfuse's own.
+.TP
+.BR \-V ", " \-\-version
+Print the version and exit.
+.SH BEHAVIOUR
+A metadata file is rendered when it is opened, and reading it returns that
+snapshot for as long as the descriptor is open; open it again to see a newer
+value. A directory listing is generated when it is read.
+.PP
+When the hub connection drops,
+.B users/
+empties and
+.B hub/
+forgets what the hub said about itself, rather than leaving a stale list that
+looks live.
+.B hub/state
+says what is happening and
+.B hub/address
+stays, since it is what was configured. The mount keeps answering throughout and
+reconnects on its own, with a delay that widens to a minute.
+.PP
+A hub that was pinned with
+.B ?kp=
+and presented a different certificate is not retried:
+.B hub/state
+reads
+.B failed
+and stays there.
+.SH EXIT STATUS
+0 when the filesystem was unmounted or the process was signalled, and 1 when it
+could not start or the session failed.
+.SH EXAMPLES
+.PP
+Mount a local hub in the foreground:
+.PP
+.RS
+.nf
+uhub\-fuse \-\-hub=adc://127.0.0.1:1511 \-f /mnt/hub
+.fi
+.RE
+.PP
+List everyone who is sharing nothing:
+.PP
+.RS
+.nf
+for u in /mnt/hub/users/*/; do
+    [ "$(cat "$u/share_size")" = 0 ] && cat "$u/nick"
+done
+.fi
+.RE
+.SH FILES
+.TP
+.I /etc/uhub/uhub\-fuse.conf
+The commented example configuration. Mode 600, since it may hold a password.
+.TP
+.IR $XDG_CACHE_HOME/uhub\-fuse , " $HOME/.cache/uhub\-fuse"
+Where downloaded content and the mount's stable identity are kept, unless
+.B cache_dir
+says otherwise.
+.SH SEE ALSO
+.BR uhub (1),
+.BR uhub\-seeder (1),
+.BR fusermount3 (1)
+.PP
+Project home page:
+.BR https://www.uhub.org/
+.SH AUTHOR
+Jan Vidar Krey

--- a/doc/uhub-fuse.conf
+++ b/doc/uhub-fuse.conf
@@ -1,0 +1,85 @@
+##
+## Configuration for uhub-fuse, which mounts an ADC hub as a directory.
+## See uhub-fuse(1) and fuse.txt.
+##
+## Every setting here can also be given on the command line, and the command
+## line wins. Keep the password in this file rather than in --password: an
+## argument is in the process's argv, which every user on the machine can read
+## out of ps. This file should be mode 600 -- uhub-fuse warns if it holds a
+## password and is readable by anyone else.
+##
+## Format is the hub's: "key = value", one per line, '#' starts a comment. A
+## value runs to the end of the line and is not interpreted further, so a
+## password may contain '#', '=' and spaces.
+##
+
+# The hub to mount. Required.
+#
+#   adc://host:port                    plaintext
+#   adcs://host:port                   TLS, but unauthenticated
+#   adcs://host:port/?kp=SHA256/BASE32 TLS, with the hub's certificate pinned
+#
+# An ADC hub's certificate is normally self-signed, so TLS on its own says the
+# connection is private and nothing about who is on the other end of it. Pin
+# the keyprint on any hub where that matters; the hub publishes it in its own
+# URL. A pinned hub that presents a different certificate is not retried.
+hub = adc://127.0.0.1:1511
+
+# The nick to log in with. This is a login like any other: the hub sees it,
+# counts it, and can ban it.
+nick = uhub-fuse
+
+# The password, on a hub where the account above is registered. Leave it unset
+# for a guest login.
+#password = 
+
+##
+## Transfers
+##
+## Reading a file means fetching it from whoever has it, over an ordinary
+## client-to-client connection. The mount is the side that listens and the peer
+## dials in, which is the only arrangement that works when the peer is passive
+## -- so this port must be reachable from the hub's other users, and the mount
+## advertises it in its INF.
+##
+
+# The port peers connect to. Two mounts on one machine need two of these.
+#transfer_port = 1514
+
+# The address to listen on. "any" binds every interface.
+#transfer_bind_addr = any
+
+# How long to wait for a file before giving up, in seconds. A reader that hits
+# this gets ETIMEDOUT rather than waiting for ever.
+#download_timeout = 60
+
+# A certificate for the transfer port, which lets the mount offer ADCS. Both or
+# neither: a certificate without its key is refused rather than quietly serving
+# in the clear. Many clients will not accept an unencrypted transfer at all.
+#tls_certificate = /etc/uhub/cert.pem
+#tls_private_key = /etc/uhub/key.pem
+#tls_version = 1.2
+
+##
+## The cache
+##
+## Downloaded files are verified against the hash that named them and kept
+## here, so reading the same file twice costs one download. A file larger than
+## max_file_size is read through a sliding window instead and never stored --
+## and, since a hash covers a whole file, never verified. See fuse.txt
+## section 5 before raising or lowering that.
+##
+
+# Where cached content goes. Empty means $XDG_CACHE_HOME/uhub-fuse, or
+# $HOME/.cache/uhub-fuse -- a mount is usually run by a person, not a service.
+#cache_dir = 
+
+# Total size of the cache, in MiB.
+#cache_size = 512
+
+# The largest file that is fetched whole, verified and kept, in MiB. Anything
+# above this is streamed.
+#max_file_size = 1024
+
+# How many files the cache may hold, whatever their size.
+#max_entries = 4096

--- a/src/fuse/bridge.c
+++ b/src/fuse/bridge.c
@@ -1,0 +1,292 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fuse/bridge.h"
+#include "network/notify.h"
+#include "util/memory.h"
+#include "util/threads.h"
+#include "util/log.h"
+
+struct fs_bridge
+{
+	void* session;
+	struct uhub_notify_handle* notify;
+
+	uhub_mutex_t mutex;
+	uhub_cond_t cond;         /** Signalled whenever a task is completed. */
+
+	struct fs_task* head;     /** Waiting to run, oldest first. */
+	struct fs_task* tail;
+	int down;
+
+	int (*interrupted)(void);
+};
+
+/** How often a waiter looks up to see whether it is still wanted. */
+#define FS_INTERRUPT_POLL_MS 200
+
+static void bridge_drain(struct uhub_notify_handle* handle, void* ptr);
+
+struct fs_bridge* fs_bridge_create(void* session)
+{
+	struct fs_bridge* bridge = (struct fs_bridge*) hub_malloc_zero(sizeof(struct fs_bridge));
+	if (!bridge)
+		return NULL;
+
+	bridge->session = session;
+
+	uhub_mutex_init(&bridge->mutex);
+	uhub_cond_init(&bridge->cond);
+
+	bridge->notify = net_notify_create(bridge_drain, bridge);
+	if (!bridge->notify)
+	{
+		uhub_cond_destroy(&bridge->cond);
+		uhub_mutex_destroy(&bridge->mutex);
+		hub_free(bridge);
+		return NULL;
+	}
+
+	return bridge;
+}
+
+void fs_bridge_destroy(struct fs_bridge* bridge)
+{
+	if (!bridge)
+		return;
+
+	fs_bridge_shutdown(bridge);
+
+	if (bridge->notify)
+		net_notify_destroy(bridge->notify);
+
+	uhub_cond_destroy(&bridge->cond);
+	uhub_mutex_destroy(&bridge->mutex);
+	hub_free(bridge);
+}
+
+/** NOTE: the mutex must be held. */
+static struct fs_task* queue_pop(struct fs_bridge* bridge)
+{
+	struct fs_task* task = bridge->head;
+
+	if (task)
+	{
+		bridge->head = task->next;
+		if (!bridge->head)
+			bridge->tail = NULL;
+		task->next = NULL;
+	}
+
+	return task;
+}
+
+void fs_bridge_complete(struct fs_bridge* bridge, struct fs_task* task, int result)
+{
+	uhub_mutex_lock(&bridge->mutex);
+	task->result = result;
+	task->done = 1;
+	/* Broadcast, not signal: every waiter shares this one condition variable,
+	   and only the task's own waiter can tell that it is the one that woke. */
+	uhub_cond_broadcast(&bridge->cond);
+	uhub_mutex_unlock(&bridge->mutex);
+}
+
+/**
+ * Run everything that has been handed over. Called on the ADC thread, from the
+ * event loop, whenever the notification pipe is readable.
+ */
+static void bridge_drain(struct uhub_notify_handle* handle, void* ptr)
+{
+	struct fs_bridge* bridge = (struct fs_bridge*) ptr;
+	struct fs_task* task;
+
+	(void) handle;
+
+	for (;;)
+	{
+		int result;
+
+		uhub_mutex_lock(&bridge->mutex);
+		task = queue_pop(bridge);
+		uhub_mutex_unlock(&bridge->mutex);
+
+		if (!task)
+			break;
+
+		/* Run it with the lock released: an operation may take a while, may
+		   park itself, and has no business serialising the other threads'
+		   submissions while it does. */
+		result = task->run(bridge->session, task);
+
+		if (result != FS_TASK_PARKED)
+			fs_bridge_complete(bridge, task, result);
+	}
+}
+
+void fs_bridge_set_interrupt_check(struct fs_bridge* bridge, int (*check)(void))
+{
+	bridge->interrupted = check;
+}
+
+/**
+ * The task an abandonment runs on the ADC thread.
+ *
+ * Both this and a completion happen there, so by the time this looks at the
+ * target it has either been completed or not, and cannot change underneath.
+ */
+struct fs_abandon_task
+{
+	struct fs_task task;
+	struct fs_task* target;
+};
+
+static int run_abandon(void* session, struct fs_task* task)
+{
+	struct fs_abandon_task* op = (struct fs_abandon_task*) task;
+	struct fs_task* target = op->target;
+
+	if (target->done)
+		return 0;   /* It arrived after all; the waiter takes the result. */
+
+	if (target->abandon)
+		target->abandon(session, target);
+
+	target->result = -EINTR;
+	target->done = 1;
+	return 0;
+}
+
+int fs_bridge_abandon(struct fs_bridge* bridge, struct fs_task* task)
+{
+	struct fs_abandon_task op;
+	int result;
+
+	memset(&op, 0, sizeof(op));
+	op.task.run = run_abandon;
+	op.target = task;
+
+	/* Not itself interruptible: it is the thing that ends the waiting. */
+	fs_bridge_submit(bridge, &op.task);
+
+	uhub_mutex_lock(&bridge->mutex);
+	result = task->done ? task->result : -EINTR;
+	uhub_mutex_unlock(&bridge->mutex);
+
+	return result;
+}
+
+int fs_bridge_submit(struct fs_bridge* bridge, struct fs_task* task)
+{
+	int result;
+
+	task->next = NULL;
+	task->done = 0;
+	task->result = 0;
+
+	uhub_mutex_lock(&bridge->mutex);
+
+	if (bridge->down)
+	{
+		uhub_mutex_unlock(&bridge->mutex);
+		return -ENOTCONN;
+	}
+
+	if (bridge->tail)
+		bridge->tail->next = task;
+	else
+		bridge->head = task;
+	bridge->tail = task;
+
+	uhub_mutex_unlock(&bridge->mutex);
+
+	/* Outside the lock: this is a write() on a pipe, and the reader takes the
+	   lock. */
+	net_notify_signal(bridge->notify, 1);
+
+	uhub_mutex_lock(&bridge->mutex);
+	while (!task->done)
+	{
+		/*
+		 * A task that cannot park is answered in the time it takes to read a
+		 * pointer, so waiting outright costs nothing and polling would only
+		 * add wake-ups. One that can park may be waiting on a peer for a
+		 * minute, and a reader that has pressed ^C should not be held for the
+		 * rest of it.
+		 */
+		if (!task->abandon || !bridge->interrupted)
+		{
+			uhub_cond_wait(&bridge->cond, &bridge->mutex);
+			continue;
+		}
+
+		uhub_cond_timedwait(&bridge->cond, &bridge->mutex, FS_INTERRUPT_POLL_MS);
+
+		if (task->done || !bridge->interrupted())
+			continue;
+
+		uhub_mutex_unlock(&bridge->mutex);
+		return fs_bridge_abandon(bridge, task);
+	}
+	result = task->result;
+	uhub_mutex_unlock(&bridge->mutex);
+
+	return result;
+}
+
+void fs_bridge_wake(struct fs_bridge* bridge)
+{
+	net_notify_signal(bridge->notify, 1);
+}
+
+void fs_bridge_shutdown(struct fs_bridge* bridge)
+{
+	struct fs_task* task;
+
+	uhub_mutex_lock(&bridge->mutex);
+
+	if (bridge->down)
+	{
+		uhub_mutex_unlock(&bridge->mutex);
+		return;
+	}
+
+	bridge->down = 1;
+
+	/* Whoever is waiting for these is waiting for a thread that has stopped. */
+	while ((task = queue_pop(bridge)) != NULL)
+	{
+		task->result = -ENOTCONN;
+		task->done = 1;
+	}
+
+	uhub_cond_broadcast(&bridge->cond);
+	uhub_mutex_unlock(&bridge->mutex);
+}
+
+int fs_bridge_is_down(struct fs_bridge* bridge)
+{
+	int down;
+
+	uhub_mutex_lock(&bridge->mutex);
+	down = bridge->down;
+	uhub_mutex_unlock(&bridge->mutex);
+
+	return down;
+}

--- a/src/fuse/bridge.h
+++ b/src/fuse/bridge.h
@@ -1,0 +1,171 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAVE_UHUB_FUSE_BRIDGE_H
+#define HAVE_UHUB_FUSE_BRIDGE_H
+
+#include "system.h"
+
+struct fs_bridge;
+struct fs_task;
+
+/**
+ * The one place the two threads meet.
+ *
+ * uhub's event loop, the ADC client, the roster and the transfer machinery are
+ * single threaded and none of it is reentrant; libfuse calls in on its own
+ * threads whenever the kernel has a request. So the ADC thread owns all of it
+ * and a FUSE thread owns none of it: a filesystem operation is packed into a
+ * task, handed over, and waited for.
+ *
+ * The handover wakes the event loop through net_notify_*, the same self-pipe
+ * the DNS resolver uses to get the main thread out of a blocking poll. Polling
+ * for work instead -- the way net_dns_process() is called once per loop -- would
+ * put the length of one poll timeout in front of every ls.
+ *
+ * A task is either answered while it is being run (the ordinary case: reading
+ * the roster is a memory access) or parked, to be completed later when a
+ * download finishes or a timeout fires. The FUSE thread cannot tell the two
+ * apart; it blocks until an answer exists either way.
+ */
+
+/** Returned by a task that will be completed later. Results are 0 or -errno. */
+#define FS_TASK_PARKED 1
+
+/**
+ * Run one operation on the ADC thread.
+ *
+ * @param session the session passed to fs_bridge_create().
+ * @param task    the task; the operation's own payload is whatever struct
+ *                embeds it.
+ * @return 0 or a negative errno when the task is finished, or FS_TASK_PARKED
+ *         when fs_bridge_complete() will be called for it later.
+ */
+typedef int (*fs_task_fn)(void* session, struct fs_task* task);
+
+struct fs_task
+{
+	fs_task_fn run;
+
+	/**
+	 * Detach a parked task, for a request that is being given up on.
+	 *
+	 * Called on the ADC thread, and only for a task that is still parked, so
+	 * whoever holds a pointer to it can drop that pointer before the waiter's
+	 * stack goes away. Leave it NULL for a task that never parks.
+	 */
+	fs_task_fn abandon;
+
+	int result;            /** 0 or -errno; valid once @c done is set. */
+	int done;
+
+	/**
+	 * The bridge's queue link while queued, and the parker's to use once the
+	 * task has parked -- fs_transfer_want() chains everybody waiting for the
+	 * same hash through it. Not touched by the bridge after run() has parked
+	 * the task.
+	 */
+	struct fs_task* next;
+};
+
+/**
+ * Set up a task: the function to run it, and no abandon hook.
+ *
+ * Every field the bridge reads is set here, so a caller cannot leave one as
+ * whatever was on the stack. A task that can park sets @c abandon afterwards.
+ */
+static inline void fs_task_init(struct fs_task* task, fs_task_fn run)
+{
+	task->run = run;
+	task->abandon = NULL;
+	task->result = 0;
+	task->done = 0;
+	task->next = NULL;
+}
+
+/**
+ * @param session passed to every task's run function. Not owned.
+ * @return NULL if the notification handle could not be created.
+ */
+extern struct fs_bridge* fs_bridge_create(void* session);
+
+extern void fs_bridge_destroy(struct fs_bridge* bridge);
+
+/**
+ * Hand @p task to the ADC thread and wait for its answer. Called on a FUSE
+ * thread.
+ *
+ * @return the task's result, or -ENOTCONN once the bridge has been shut down.
+ */
+extern int fs_bridge_submit(struct fs_bridge* bridge, struct fs_task* task);
+
+/**
+ * Answer a parked task. Called on the ADC thread.
+ *
+ * The task is the waiter's stack memory and is dead the moment this returns:
+ * it may be freed under the caller before the next instruction.
+ */
+extern void fs_bridge_complete(struct fs_bridge* bridge, struct fs_task* task, int result);
+
+/**
+ * Fail everything queued and refuse everything to come, with -ENOTCONN.
+ *
+ * The ADC thread calls this when it stops. A FUSE thread blocked on a task
+ * whose answer will now never arrive would otherwise hang the mount, and an
+ * unmount cannot proceed while a request is in flight.
+ *
+ * Tasks already parked belong to whoever parked them; this does not touch
+ * them, so a parked task must be failed by its owner during teardown.
+ */
+extern void fs_bridge_shutdown(struct fs_bridge* bridge);
+
+/**
+ * Give up on a request the caller is no longer waiting for.
+ *
+ * The FUSE thread calls this when the kernel says its request has been
+ * interrupted -- a reader hitting ^C on a download that has not arrived. The
+ * detaching itself happens on the ADC thread, so a task cannot be abandoned
+ * and completed at the same time, and the waiter's stack is never written to
+ * after this returns.
+ *
+ * @return the task's result if it completed after all, or -EINTR.
+ */
+extern int fs_bridge_abandon(struct fs_bridge* bridge, struct fs_task* task);
+
+/**
+ * Say how to ask whether the current request has been interrupted.
+ *
+ * The bridge polls this while waiting. It exists so that bridge.c needs to know
+ * nothing about libfuse; fs.c passes fuse_interrupted().
+ */
+extern void fs_bridge_set_interrupt_check(struct fs_bridge* bridge, int (*check)(void));
+
+/**
+ * Wake the event loop without submitting anything.
+ *
+ * The ADC thread spends its time blocked in a poll, so a flag another thread
+ * sets is not noticed until something happens on a socket. This is how the
+ * flag gets looked at. Safe from any thread.
+ */
+extern void fs_bridge_wake(struct fs_bridge* bridge);
+
+/** Has fs_bridge_shutdown() been called? Safe from either thread. */
+extern int fs_bridge_is_down(struct fs_bridge* bridge);
+
+#endif /* HAVE_UHUB_FUSE_BRIDGE_H */

--- a/src/fuse/chatlog.c
+++ b/src/fuse/chatlog.c
@@ -1,0 +1,161 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fuse/chatlog.h"
+#include "util/memory.h"
+
+struct fs_chatlog* fs_chatlog_create(size_t capacity)
+{
+	struct fs_chatlog* log = (struct fs_chatlog*) hub_malloc_zero(sizeof(struct fs_chatlog));
+
+	if (!log)
+		return NULL;
+
+	log->capacity = capacity ? capacity : FS_CHATLOG_SIZE;
+	log->data = (char*) hub_malloc(log->capacity);
+
+	if (!log->data)
+	{
+		hub_free(log);
+		return NULL;
+	}
+
+	return log;
+}
+
+void fs_chatlog_destroy(struct fs_chatlog* log)
+{
+	if (!log)
+		return;
+
+	hub_free(log->data);
+	hub_free(log);
+}
+
+void fs_chatlog_clear(struct fs_chatlog* log)
+{
+	if (!log)
+		return;
+
+	/* The offsets do not go backwards: a reader holding one from before the
+	   clear must not be handed unrelated bytes as though they were the ones it
+	   asked for. */
+	log->used = 0;
+	log->head = 0;
+	log->base = log->end;
+}
+
+void fs_chatlog_append(struct fs_chatlog* log, const char* data, size_t len)
+{
+	size_t tail;
+	size_t first;
+
+	if (!log || !data || !len)
+		return;
+
+	/* More than fits: everything already held is going anyway, so keep the
+	   last capacity bytes of what has just arrived. */
+	if (len >= log->capacity)
+	{
+		data += len - log->capacity;
+		log->end += len - log->capacity;
+		len = log->capacity;
+		log->used = 0;
+		log->head = 0;
+		log->base = log->end;
+	}
+
+	/* Evict from the front for whatever room is still missing. */
+	if (len > log->capacity - log->used)
+	{
+		size_t evict = len - (log->capacity - log->used);
+
+		log->head = (log->head + evict) % log->capacity;
+		log->used -= evict;
+		log->base += evict;
+	}
+
+	tail = (log->head + log->used) % log->capacity;
+	first = log->capacity - tail;
+	if (first > len)
+		first = len;
+
+	memcpy(&log->data[tail], data, first);
+	if (len > first)
+		memcpy(log->data, &data[first], len - first);
+
+	log->used += len;
+	log->end += len;
+}
+
+void fs_chatlog_append_line(struct fs_chatlog* log, const char* line)
+{
+	size_t start = 0;
+	size_t n;
+
+	if (!log || !line)
+		return;
+
+	for (n = 0; line[n]; n++)
+	{
+		if (line[n] != '\n' && line[n] != '\r')
+			continue;
+
+		fs_chatlog_append(log, &line[start], n - start);
+		fs_chatlog_append(log, " ", 1);
+		start = n + 1;
+	}
+
+	fs_chatlog_append(log, &line[start], n - start);
+	fs_chatlog_append(log, "\n", 1);
+}
+
+size_t fs_chatlog_read(const struct fs_chatlog* log, uint64_t offset, char* buf, size_t len)
+{
+	uint64_t available;
+	size_t index;
+	size_t first;
+
+	if (!log || !buf || !len || offset >= log->end)
+		return 0;
+
+	/* Behind the window: give what is still held, starting at the oldest byte. */
+	if (offset < log->base)
+		offset = log->base;
+
+	available = log->end - offset;
+	if (available < len)
+		len = (size_t) available;
+
+	index = (size_t) ((log->head + (offset - log->base)) % log->capacity);
+	first = log->capacity - index;
+	if (first > len)
+		first = len;
+
+	memcpy(buf, &log->data[index], first);
+	if (len > first)
+		memcpy(&buf[first], log->data, len - first);
+
+	return len;
+}
+
+uint64_t fs_chatlog_size(const struct fs_chatlog* log)
+{
+	return log ? log->end : 0;
+}

--- a/src/fuse/chatlog.h
+++ b/src/fuse/chatlog.h
@@ -1,0 +1,91 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAVE_UHUB_FUSE_CHATLOG_H
+#define HAVE_UHUB_FUSE_CHATLOG_H
+
+#include "system.h"
+
+/**
+ * The chat, as a file that grows.
+ *
+ * Unlike every other file in the mount, chat/main is not a value that is
+ * rendered when it is opened: it is a stream, and the whole point of it is
+ * that `tail -f` follows it. So it is addressed the way a file being appended
+ * to is addressed -- by an offset that only ever increases, with the size
+ * reported by stat() being the total number of bytes the log has ever held.
+ *
+ * What is *kept* is a window of the most recent bytes; a mount that ran for a
+ * month would otherwise be a month of chat in memory. A reader that asks for
+ * an offset that has been evicted is given the oldest bytes still held rather
+ * than an error: a reader that fell that far behind has already lost the gap,
+ * and failing its read would only lose the rest as well.
+ */
+
+/** Bytes of history kept. Older ones are dropped as new ones arrive. */
+#define FS_CHATLOG_SIZE (256 * 1024)
+
+struct fs_chatlog
+{
+	char* data;        /** Ring of @c capacity bytes. */
+	size_t capacity;
+	size_t used;       /** Bytes held, <= capacity. */
+	size_t head;       /** Index in @c data of the oldest byte held. */
+	uint64_t base;     /** Absolute offset of that oldest byte. */
+	uint64_t end;      /** Absolute offset just past the newest byte. */
+};
+
+/** @return NULL on OOM. @p capacity of 0 selects FS_CHATLOG_SIZE. */
+extern struct fs_chatlog* fs_chatlog_create(size_t capacity);
+
+extern void fs_chatlog_destroy(struct fs_chatlog* log);
+
+/**
+ * Append @p len bytes.
+ *
+ * More than the whole capacity at once keeps the tail of it, which is the part
+ * a reader would have ended up with anyway.
+ */
+extern void fs_chatlog_append(struct fs_chatlog* log, const char* data, size_t len);
+
+/**
+ * Append a line, adding the terminating newline.
+ *
+ * Any newline inside @p line is replaced by a space: one message is one line,
+ * so that the file can be read a line at a time by anything that reads lines.
+ * A hub cannot send an unescaped newline in a chat message anyway -- the ADC
+ * grammar has no way to spell one -- but the mount does not depend on that.
+ */
+extern void fs_chatlog_append_line(struct fs_chatlog* log, const char* line);
+
+/**
+ * Copy out at most @p len bytes from absolute offset @p offset.
+ *
+ * @return the number of bytes copied. 0 means the offset is at or past the end
+ *         of the log, which is the end of file a reader polls for.
+ */
+extern size_t fs_chatlog_read(const struct fs_chatlog* log, uint64_t offset, char* buf, size_t len);
+
+/** The total number of bytes ever appended: what stat() reports as the size. */
+extern uint64_t fs_chatlog_size(const struct fs_chatlog* log);
+
+/** Drop everything held. The absolute offsets keep going up. */
+extern void fs_chatlog_clear(struct fs_chatlog* log);
+
+#endif /* HAVE_UHUB_FUSE_CHATLOG_H */

--- a/src/fuse/config.c
+++ b/src/fuse/config.c
@@ -1,0 +1,437 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fuse/config.h"
+#include "util/log.h"
+#include "util/memory.h"
+#include "util/misc.h"
+
+#include <sys/stat.h>
+
+enum fs_cfg_type
+{
+	FS_CFG_STR,
+	FS_CFG_INT
+};
+
+/** One recognised key, and where its value goes. */
+struct fs_cfg_key
+{
+	const char* name;
+	enum fs_cfg_type type;
+	size_t offset;        /** of the field inside struct fs_config */
+	int secret;           /** Setting it makes the file worth protecting. */
+	const char* def_str;  /** FS_CFG_STR default; NULL means "". */
+	int def_int;          /** FS_CFG_INT default. */
+	int min;              /** FS_CFG_INT inclusive range. */
+	int max;
+	const char* values;   /** FS_CFG_STR: comma separated allowed set, or NULL. */
+};
+
+#define STR_KEY(k, member, secret, def, vals) \
+	{ k, FS_CFG_STR, offsetof(struct fs_config, member), secret, def, 0, 0, 0, vals }
+#define INT_KEY(k, member, def, lo, hi) \
+	{ k, FS_CFG_INT, offsetof(struct fs_config, member), 0, NULL, def, lo, hi, NULL }
+
+/*
+ * The TLS defaults are the hub's and the seeder's, so an operator who knows
+ * uhub.conf does not have to learn a third set of cipher strings.
+ */
+static const struct fs_cfg_key fs_config_keys[] = {
+	STR_KEY("hub",                address,            0, NULL,        NULL),
+	STR_KEY("nick",               nick,               0, "uhub-fuse", NULL),
+	STR_KEY("password",           password,           1, NULL,        NULL),
+
+	INT_KEY("transfer_port",      transfer_port,      1514, 1024, 65535),
+	STR_KEY("transfer_bind_addr", transfer_bind_addr, 0, "any",       NULL),
+	INT_KEY("download_timeout",   download_timeout,   60,   1,    3600),
+
+	STR_KEY("tls_certificate",    tls_certificate,    0, NULL,        NULL),
+	STR_KEY("tls_private_key",    tls_private_key,    0, NULL,        NULL),
+	STR_KEY("tls_version",        tls_version,        0, "1.2",       "1.2,1.3"),
+	STR_KEY("tls_ciphersuite",    tls_ciphersuite,    0,
+		"ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS", NULL),
+	STR_KEY("tls_ciphersuites",   tls_ciphersuites,   0,
+		"TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256", NULL),
+
+	STR_KEY("cache_dir",          cache_dir,          0, NULL,        NULL),
+	INT_KEY("cache_size",         cache_size,         512,  1,    1048576),
+	INT_KEY("max_file_size",      max_file_size,      1024, 1,    1048576),
+	INT_KEY("max_entries",        max_entries,        4096, 1,    1000000),
+
+	{ NULL, FS_CFG_STR, 0, 0, NULL, 0, 0, 0, NULL }
+};
+
+static const struct fs_cfg_key* fs_config_lookup(const char* key)
+{
+	size_t n;
+
+	for (n = 0; fs_config_keys[n].name; n++)
+		if (strcmp(fs_config_keys[n].name, key) == 0)
+			return &fs_config_keys[n];
+
+	return NULL;
+}
+
+static char** fs_str_field(struct fs_config* cfg, const struct fs_cfg_key* key)
+{
+	return (char**) (void*) (((char*) cfg) + key->offset);
+}
+
+static int* fs_int_field(struct fs_config* cfg, const struct fs_cfg_key* key)
+{
+	return (int*) (void*) (((char*) cfg) + key->offset);
+}
+
+int fs_config_default_cache_dir(char* buf, size_t size)
+{
+	const char* xdg = getenv("XDG_CACHE_HOME");
+	const char* home = getenv("HOME");
+	int len;
+
+	if (xdg && *xdg)
+		len = snprintf(buf, size, "%s/uhub-fuse", xdg);
+	else if (home && *home)
+		len = snprintf(buf, size, "%s/.cache/uhub-fuse", home);
+	else
+		return 0;
+
+	return (len > 0 && (size_t) len < size);
+}
+
+void fs_config_defaults(struct fs_config* cfg)
+{
+	size_t n;
+
+	memset(cfg, 0, sizeof(*cfg));
+
+	for (n = 0; fs_config_keys[n].name; n++)
+	{
+		const struct fs_cfg_key* key = &fs_config_keys[n];
+
+		if (key->type == FS_CFG_STR)
+			*fs_str_field(cfg, key) = hub_strdup(key->def_str ? key->def_str : "");
+		else
+			*fs_int_field(cfg, key) = key->def_int;
+	}
+}
+
+void fs_config_free(struct fs_config* cfg)
+{
+	size_t n;
+
+	if (!cfg)
+		return;
+
+	for (n = 0; fs_config_keys[n].name; n++)
+	{
+		const struct fs_cfg_key* key = &fs_config_keys[n];
+		char** member;
+
+		if (key->type != FS_CFG_STR)
+			continue;
+
+		member = fs_str_field(cfg, key);
+
+		/* A password does not need to outlive the login, and the process may
+		   go on running for weeks after it. */
+		if (key->secret && *member)
+			memset(*member, 0, strlen(*member));
+
+		hub_free(*member);
+		*member = NULL;
+	}
+}
+
+/**
+ * Unlike the hub's apply_integer(), this rejects trailing garbage: "8080x" is a
+ * typo, not the number 8080, and a configuration that means something other
+ * than what it says is worse than one that refuses to load.
+ */
+static int apply_integer(const struct fs_cfg_key* key, const char* data, int* target)
+{
+	char* endptr = NULL;
+	long val;
+
+	errno = 0;
+	val = strtol(data, &endptr, 10);
+
+	if (endptr == data || !endptr || *endptr != '\0')
+	{
+		LOG_ERROR("Invalid numeric value for configuration key '%s': \"%s\"", key->name, data);
+		return 0;
+	}
+
+	if (errno == ERANGE || val < (long) key->min || val > (long) key->max)
+	{
+		LOG_ERROR("Value out of range for configuration key '%s': \"%s\" (allowed: %d-%d)",
+			key->name, data, key->min, key->max);
+		return 0;
+	}
+
+	*target = (int) val;
+	return 1;
+}
+
+/** Check a value against a comma separated set. An empty set permits anything. */
+static int value_in_set(const struct fs_cfg_key* key, const char* data)
+{
+	const char* p = key->values;
+	size_t len = strlen(data);
+
+	if (!p || !*p)
+		return 1;
+
+	while (*p)
+	{
+		const char* end = strchr(p, ',');
+		size_t n = end ? (size_t) (end - p) : strlen(p);
+
+		if (n == len && strncmp(p, data, n) == 0)
+			return 1;
+
+		if (!end)
+			break;
+		p = end + 1;
+	}
+
+	LOG_ERROR("Invalid value for configuration key '%s': \"%s\" (must be one of: %s)",
+		key->name, data, key->values);
+	return 0;
+}
+
+int fs_config_set(struct fs_config* cfg, const char* key_name, const char* value)
+{
+	const struct fs_cfg_key* key = fs_config_lookup(key_name);
+	char** member;
+	char* copy;
+
+	if (!cfg || !key || !value)
+		return 0;
+
+	if (key->type == FS_CFG_INT)
+		return apply_integer(key, value, fs_int_field(cfg, key));
+
+	if (!value_in_set(key, value))
+		return 0;
+
+	copy = hub_strdup(value);
+	if (!copy)
+		return 0;
+
+	member = fs_str_field(cfg, key);
+	hub_free(*member);
+	*member = copy;
+	return 1;
+}
+
+int fs_config_parse_line(char* line, int line_no, struct fs_config* cfg)
+{
+	const struct fs_cfg_key* key_def;
+	char* pos;
+	char* key;
+	char* value;
+
+	if (!line || !cfg)
+		return 0;
+
+	line = strip_white_space(line);
+
+	if (!*line || line[0] == '#')
+		return 1;
+
+	if (!is_valid_utf8(line))
+		LOG_WARN("Invalid utf-8 characters on line %d", line_no);
+
+	pos = strchr(line, '=');
+	if (!pos)
+	{
+		LOG_FATAL("Configuration parse error on line %d: expected 'key = value'", line_no);
+		return 0;
+	}
+
+	pos[0] = '\0';
+	key = strip_white_space(line);
+
+	if (!*key)
+	{
+		LOG_FATAL("Configuration parse error on line %d: missing key", line_no);
+		return 0;
+	}
+
+	key_def = fs_config_lookup(key);
+	if (!key_def)
+	{
+		LOG_FATAL("Unknown configuration key '%s' on line %d", key, line_no);
+		return 0;
+	}
+
+	/*
+	 * The value runs to the end of the line, with the surrounding whitespace
+	 * removed and nothing else interpreted -- no comment character, no quote
+	 * processing. A password is the reason: '#' is an ordinary character in
+	 * one, and a parser that treated it as the start of a comment would
+	 * silently truncate the secret and then fail the login for no visible
+	 * reason.
+	 */
+	value = strip_white_space(&pos[1]);
+
+	if (!fs_config_set(cfg, key, value))
+	{
+		LOG_FATAL("Out of memory parsing configuration line %d", line_no);
+		return 0;
+	}
+
+	return 1;
+}
+
+static char* fs_config_slurp(const char* file)
+{
+	FILE* fh;
+	long size;
+	size_t got;
+	char* buf;
+
+	fh = fopen(file, "rb");
+	if (!fh)
+	{
+		LOG_FATAL("Unable to open configuration file %s: %s", file, strerror(errno));
+		return NULL;
+	}
+
+	if (fseek(fh, 0, SEEK_END) != 0 || (size = ftell(fh)) < 0 || fseek(fh, 0, SEEK_SET) != 0)
+	{
+		LOG_FATAL("Unable to read configuration file %s: not a regular file?", file);
+		fclose(fh);
+		return NULL;
+	}
+
+	if (size > FS_CONFIG_MAX_FILE)
+	{
+		LOG_FATAL("Configuration file %s is too large (%ld bytes, max %d)", file, size, FS_CONFIG_MAX_FILE);
+		fclose(fh);
+		return NULL;
+	}
+
+	buf = (char*) hub_malloc((size_t) size + 1);
+	if (!buf)
+	{
+		LOG_FATAL("Out of memory reading configuration file %s", file);
+		fclose(fh);
+		return NULL;
+	}
+
+	got = fread(buf, 1, (size_t) size, fh);
+	if (ferror(fh))
+	{
+		LOG_FATAL("Unable to read configuration file %s: %s", file, strerror(errno));
+		hub_free(buf);
+		fclose(fh);
+		return NULL;
+	}
+	fclose(fh);
+
+	buf[got] = '\0';
+	return buf;
+}
+
+/** Say so if a file holding a secret is readable by anyone but its owner. */
+static void fs_config_check_mode(const char* file, const struct fs_config* cfg)
+{
+	struct stat st;
+
+	if (!cfg->password || !*cfg->password)
+		return;
+
+	if (stat(file, &st) != 0)
+		return;
+
+	if (st.st_mode & (S_IRGRP | S_IROTH))
+		LOG_WARN("%s holds a password and is readable by others; chmod 600 it", file);
+}
+
+int fs_config_read(const char* file, struct fs_config* cfg)
+{
+	char* buf;
+	char* line;
+	int line_no = 1;
+	int ok = 1;
+
+	if (!cfg)
+		return 0;
+
+	if (!file)
+	{
+		LOG_FATAL("No configuration file given.");
+		return 0;
+	}
+
+	buf = fs_config_slurp(file);
+	if (!buf)
+	{
+		fs_config_free(cfg);
+		return 0;
+	}
+
+	/* Split on '\n'. A trailing '\r' from a CRLF file is whitespace to
+	   strip_white_space(), so it needs no handling of its own. */
+	line = buf;
+	while (ok)
+	{
+		char* eol = strchr(line, '\n');
+		if (eol)
+			*eol = '\0';
+
+		ok = fs_config_parse_line(line, line_no, cfg);
+
+		if (!eol)
+			break;
+
+		line = eol + 1;
+		line_no++;
+	}
+
+	/* The file may have held a password; do not leave it in freed memory. */
+	memset(buf, 0, strlen(buf));
+	hub_free(buf);
+
+	if (!ok)
+	{
+		fs_config_free(cfg);
+		return 0;
+	}
+
+	/*
+	 * A certificate without its key, or the other way round, fails quietly:
+	 * the transfer port would come up serving plain ADC while the operator
+	 * believes it is serving ADCS. Refuse the file instead.
+	 */
+	if (!!(cfg->tls_certificate && *cfg->tls_certificate) !=
+	    !!(cfg->tls_private_key && *cfg->tls_private_key))
+	{
+		LOG_FATAL("Configuration error in %s: tls_certificate and tls_private_key must be "
+			"set together (only '%s' is set)", file,
+			(cfg->tls_certificate && *cfg->tls_certificate) ? "tls_certificate" : "tls_private_key");
+		fs_config_free(cfg);
+		return 0;
+	}
+
+	fs_config_check_mode(file, cfg);
+	return 1;
+}

--- a/src/fuse/config.h
+++ b/src/fuse/config.h
@@ -1,0 +1,117 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAVE_UHUB_FUSE_CONFIG_H
+#define HAVE_UHUB_FUSE_CONFIG_H
+
+#include "system.h"
+
+/**
+ * Where a mount gets its settings.
+ *
+ * Everything here can also be given on the command line, and the command line
+ * wins. The file exists for one reason above the others: a password passed as
+ * --password=... is in the process's argv, which every user on the machine can
+ * read out of ps. uhub-seeder keeps its bot password in a file installed 0600
+ * for exactly that reason, and this is the same arrangement.
+ *
+ * The format is the hub's: "key = value", one per line, # to end of line for
+ * comments, unknown keys refused rather than ignored.
+ */
+
+/** Largest configuration file that will be read, in bytes. */
+#define FS_CONFIG_MAX_FILE (64 * 1024)
+
+struct fs_config
+{
+	/* Hub connection */
+	char* address;         /** hub = adc[s]://host:port[/?kp=...] */
+	char* nick;            /** nick = NAME */
+	char* password;        /** password = SECRET */
+
+	/*
+	 * Transfers. The mount has to be dialable to fetch anything from a passive
+	 * peer -- two passive clients cannot connect to each other at all -- so it
+	 * listens, exactly as uhub-seeder does, and says so in its INF.
+	 */
+	int   transfer_port;
+	char* transfer_bind_addr;
+	int   download_timeout;   /** Seconds before a fetch is given up on. */
+
+	/* TLS on the transfer port. Both or neither; ADCS is advertised only when
+	   there is a certificate to complete a handshake with. */
+	char* tls_certificate;
+	char* tls_private_key;
+	char* tls_version;
+	char* tls_ciphersuite;
+	char* tls_ciphersuites;
+
+	/* The content cache downloaded files land in. */
+	char* cache_dir;          /** Empty means $XDG_CACHE_HOME/uhub-fuse. */
+	int   cache_size;         /** MiB */
+	int   max_file_size;      /** MiB */
+	int   max_entries;
+};
+
+/**
+ * Where the cache goes when cache_dir is empty: $XDG_CACHE_HOME/uhub-fuse, or
+ * $HOME/.cache/uhub-fuse. A mount is usually run by a person rather than a
+ * service, and /var/lib is not theirs to write to.
+ *
+ * @return 1 on success.
+ */
+extern int fs_config_default_cache_dir(char* buf, size_t size);
+
+/** Zero it and apply the defaults. */
+extern void fs_config_defaults(struct fs_config* cfg);
+
+/** Release every string; leaves the struct zeroed and reusable. */
+extern void fs_config_free(struct fs_config* cfg);
+
+/**
+ * Read @p file into @p cfg, over the defaults.
+ *
+ * A file that holds a password and is readable by anyone but its owner is
+ * warned about, and read anyway: refusing would leave an operator with a
+ * mounted filesystem and no way to say why, and the warning is the part that
+ * gets the mode fixed.
+ *
+ * @return 1 on success. On failure @p cfg is left zeroed and the reason has
+ *         been logged.
+ */
+extern int fs_config_read(const char* file, struct fs_config* cfg);
+
+/**
+ * Set one key, as if it had been read from a file.
+ *
+ * Used for the command line, so that both routes agree on what a value means.
+ * @return 1 if the key is known and the value was stored.
+ */
+extern int fs_config_set(struct fs_config* cfg, const char* key, const char* value);
+
+/**
+ * Parse one "key = value" line into @p cfg. Exposed for the tests.
+ *
+ * @param line    modified in place.
+ * @param line_no used in messages.
+ * @return 1 if the line was blank, a comment, or a key that was stored.
+ */
+extern int fs_config_parse_line(char* line, int line_no, struct fs_config* cfg);
+
+#endif /* HAVE_UHUB_FUSE_CONFIG_H */

--- a/src/fuse/filelist.c
+++ b/src/fuse/filelist.c
@@ -22,8 +22,11 @@
 #include "util/memory.h"
 #include "util/misc.h"
 
-#include <bzlib.h>
 #include <ctype.h>
+
+#ifdef HAVE_BZLIB
+#include <bzlib.h>
+#endif
 
 /** Growth step while decompressing, and the initial buffer. */
 #define FS_FILELIST_CHUNK (256 * 1024)
@@ -67,6 +70,29 @@ int fs_filelist_safe_name(const char* name, char* buf, size_t size)
 }
 
 /* ------------------------------------------------------- decompression */
+
+#ifndef HAVE_BZLIB
+
+/*
+ * Built without libbz2.
+ *
+ * A file list arrives compressed and there is nothing here to decompress it
+ * with, so browsing a share does not work in such a build -- which is why
+ * uhub-fuse requires the library and only the test suite may be built without
+ * it. Everything above this point, including the parser that reads what a peer
+ * sent, is unaffected and still built and tested.
+ */
+char* fs_filelist_decompress(const void* data, size_t len, size_t* out_len)
+{
+	(void) data;
+	(void) len;
+	(void) out_len;
+
+	LOG_DEBUG("filelist: built without bzip2 support");
+	return NULL;
+}
+
+#else
 
 char* fs_filelist_decompress(const void* data, size_t len, size_t* out_len)
 {
@@ -163,6 +189,8 @@ char* fs_filelist_decompress(const void* data, size_t len, size_t* out_len)
 
 	return out;
 }
+
+#endif /* HAVE_BZLIB */
 
 /* -------------------------------------------------------------- XML */
 

--- a/src/fuse/filelist.c
+++ b/src/fuse/filelist.c
@@ -1,0 +1,713 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fuse/filelist.h"
+#include "util/log.h"
+#include "util/memory.h"
+#include "util/misc.h"
+
+#include <bzlib.h>
+#include <ctype.h>
+
+/** Growth step while decompressing, and the initial buffer. */
+#define FS_FILELIST_CHUNK (256 * 1024)
+
+struct fs_filelist
+{
+	struct fs_filelist_node* root;   /** First entry at the top level. */
+	size_t count;
+};
+
+/* ------------------------------------------------------------ names */
+
+int fs_filelist_safe_name(const char* name, char* buf, size_t size)
+{
+	size_t n = 0;
+
+	if (!name || !buf || size < 2)
+		return 0;
+
+	for (; name[n]; n++)
+	{
+		unsigned char c = (unsigned char) name[n];
+
+		if (n + 1 >= size)
+			return 0;   /* Refused, not truncated: two long names would collide. */
+
+		/* A separator would make one name into two path components, and a
+		   control character is not something a filesystem should hand back. */
+		if (c == '/' || c < 0x20 || c == 0x7f)
+			buf[n] = '_';
+		else
+			buf[n] = (char) c;
+	}
+
+	buf[n] = '\0';
+
+	if (n == 0 || strcmp(buf, ".") == 0 || strcmp(buf, "..") == 0)
+		return 0;
+
+	return 1;
+}
+
+/* ------------------------------------------------------- decompression */
+
+char* fs_filelist_decompress(const void* data, size_t len, size_t* out_len)
+{
+	bz_stream stream;
+	char* out;
+	size_t capacity = FS_FILELIST_CHUNK;
+	size_t used = 0;
+	int rc;
+
+	if (!data || !len)
+		return NULL;
+
+	/* bzlib speaks unsigned int, and a file list arriving in one piece is
+	   bounded by the cache's per-file ceiling long before this. */
+	if (len > UINT_MAX)
+		return NULL;
+
+	out = (char*) hub_malloc(capacity);
+	if (!out)
+		return NULL;
+
+	memset(&stream, 0, sizeof(stream));
+	if (BZ2_bzDecompressInit(&stream, 0, 0) != BZ_OK)
+	{
+		hub_free(out);
+		return NULL;
+	}
+
+	stream.next_in = (char*) data;
+	stream.avail_in = (unsigned int) len;
+
+	for (;;)
+	{
+		stream.next_out = out + used;
+		stream.avail_out = (unsigned int) (capacity - used);
+
+		rc = BZ2_bzDecompress(&stream);
+		used = capacity - stream.avail_out;
+
+		if (rc == BZ_STREAM_END)
+			break;
+
+		if (rc != BZ_OK)
+		{
+			BZ2_bzDecompressEnd(&stream);
+			hub_free(out);
+			return NULL;
+		}
+
+		if (stream.avail_out == 0)
+		{
+			char* bigger;
+
+			/*
+			 * A compression bomb is a few kilobytes that expand without end,
+			 * and this runs against bytes a stranger sent. The ceiling is what
+			 * stops it; growing geometrically only decides how often we ask
+			 * for more memory on the way there.
+			 */
+			if (capacity >= FS_FILELIST_MAX)
+			{
+				LOG_DEBUG("filelist: refusing a list larger than %d bytes", FS_FILELIST_MAX);
+				BZ2_bzDecompressEnd(&stream);
+				hub_free(out);
+				return NULL;
+			}
+
+			capacity = (capacity > FS_FILELIST_MAX / 2) ? FS_FILELIST_MAX : capacity * 2;
+
+			bigger = (char*) hub_realloc(out, capacity);
+			if (!bigger)
+			{
+				BZ2_bzDecompressEnd(&stream);
+				hub_free(out);
+				return NULL;
+			}
+			out = bigger;
+			continue;
+		}
+
+		if (stream.avail_in == 0 && stream.avail_out != 0)
+		{
+			/* The stream ended without saying so: truncated. */
+			BZ2_bzDecompressEnd(&stream);
+			hub_free(out);
+			return NULL;
+		}
+	}
+
+	BZ2_bzDecompressEnd(&stream);
+
+	if (out_len)
+		*out_len = used;
+
+	return out;
+}
+
+/* -------------------------------------------------------------- XML */
+
+/*
+ * Not a general XML parser, and not trying to be one.
+ *
+ * A file list is a document with three element types and five attributes, and
+ * anything else in it is of no interest. So this scans for the elements it
+ * knows and steps over everything else -- comments, processing instructions,
+ * namespaces, whatever a generator saw fit to add -- rather than modelling a
+ * language. What it will not do is grow a feature that reads from anywhere but
+ * the buffer it was given: no entity definitions, no external references, no
+ * DTD. Those are how XML parsers become file-disclosure bugs, and a file list
+ * has never needed any of them.
+ */
+
+struct fl_parser
+{
+	const char* data;
+	size_t len;
+	size_t pos;
+	struct fs_filelist* list;
+	struct fs_filelist_node* parent;    /** NULL at the top level. */
+	struct fs_filelist_node* last;      /** Last node added to @c parent. */
+	int depth;
+};
+
+static int fl_eof(struct fl_parser* p)
+{
+	return p->pos >= p->len;
+}
+
+static void fl_skip_space(struct fl_parser* p)
+{
+	while (!fl_eof(p) && is_white_space(p->data[p->pos]))
+		p->pos++;
+}
+
+/** Decode the five named entities and numeric references, in place. */
+static void fl_decode_entities(char* text)
+{
+	char* out = text;
+	char* in = text;
+
+	while (*in)
+	{
+		if (*in != '&')
+		{
+			*out++ = *in++;
+			continue;
+		}
+
+		if (strncmp(in, "&amp;", 5) == 0)       { *out++ = '&';  in += 5; }
+		else if (strncmp(in, "&lt;", 4) == 0)   { *out++ = '<';  in += 4; }
+		else if (strncmp(in, "&gt;", 4) == 0)   { *out++ = '>';  in += 4; }
+		else if (strncmp(in, "&quot;", 6) == 0) { *out++ = '"';  in += 6; }
+		else if (strncmp(in, "&apos;", 6) == 0) { *out++ = '\''; in += 6; }
+		else if (in[1] == '#')
+		{
+			unsigned long value = 0;
+			char* end = NULL;
+			int hex = (in[2] == 'x' || in[2] == 'X');
+
+			errno = 0;
+			value = strtoul(&in[hex ? 3 : 2], &end, hex ? 16 : 10);
+
+			if (!end || *end != ';' || errno == ERANGE || value == 0 || value > 0x10FFFF)
+			{
+				*out++ = *in++;   /* Not a reference; an ampersand is just an ampersand. */
+				continue;
+			}
+
+			/* Encoded as UTF-8, because that is what the rest of the mount is.
+			   A surrogate or an overlong form is not written at all. */
+			if (value < 0x80)
+			{
+				*out++ = (char) value;
+			}
+			else if (value < 0x800)
+			{
+				*out++ = (char) (0xC0 | (value >> 6));
+				*out++ = (char) (0x80 | (value & 0x3F));
+			}
+			else if (value >= 0xD800 && value <= 0xDFFF)
+			{
+				/* Not a character. */
+			}
+			else if (value < 0x10000)
+			{
+				*out++ = (char) (0xE0 | (value >> 12));
+				*out++ = (char) (0x80 | ((value >> 6) & 0x3F));
+				*out++ = (char) (0x80 | (value & 0x3F));
+			}
+			else
+			{
+				*out++ = (char) (0xF0 | (value >> 18));
+				*out++ = (char) (0x80 | ((value >> 12) & 0x3F));
+				*out++ = (char) (0x80 | ((value >> 6) & 0x3F));
+				*out++ = (char) (0x80 | (value & 0x3F));
+			}
+
+			in = end + 1;
+		}
+		else
+		{
+			*out++ = *in++;
+		}
+	}
+
+	*out = '\0';
+}
+
+/** One attribute: name="value". @return 1 if one was read. */
+static int fl_read_attribute(struct fl_parser* p, char* name, size_t name_size,
+                             char* value, size_t value_size)
+{
+	size_t n = 0;
+	char quote;
+
+	fl_skip_space(p);
+
+	while (!fl_eof(p) && (isalnum((unsigned char) p->data[p->pos]) ||
+	                      p->data[p->pos] == '_' || p->data[p->pos] == '-' ||
+	                      p->data[p->pos] == ':'))
+	{
+		if (n + 1 < name_size)
+			name[n++] = p->data[p->pos];
+		p->pos++;
+	}
+
+	name[n < name_size ? n : name_size - 1] = '\0';
+
+	if (!n)
+		return 0;
+
+	fl_skip_space(p);
+	if (fl_eof(p) || p->data[p->pos] != '=')
+		return 0;
+	p->pos++;
+
+	fl_skip_space(p);
+	if (fl_eof(p) || (p->data[p->pos] != '"' && p->data[p->pos] != '\''))
+		return 0;
+
+	quote = p->data[p->pos++];
+
+	n = 0;
+	while (!fl_eof(p) && p->data[p->pos] != quote)
+	{
+		if (n + 1 >= value_size)
+			return 0;   /* An oversized attribute is a refusal, not a truncation. */
+
+		value[n++] = p->data[p->pos++];
+	}
+
+	if (fl_eof(p))
+		return 0;
+
+	p->pos++;   /* the closing quote */
+	value[n] = '\0';
+	fl_decode_entities(value);
+	return 1;
+}
+
+static struct fs_filelist_node* fl_new_node(struct fl_parser* p, const char* raw_name, int is_dir)
+{
+	struct fs_filelist_node* node;
+	char safe[FS_FILELIST_NAME_MAX + 1];
+
+	if (p->list->count >= FS_FILELIST_MAX_NODES)
+		return NULL;
+
+	if (!fs_filelist_safe_name(raw_name, safe, sizeof(safe)))
+		return NULL;
+
+	node = (struct fs_filelist_node*) hub_malloc_zero(sizeof(struct fs_filelist_node));
+	if (!node)
+		return NULL;
+
+	node->name = hub_strdup(safe);
+	if (!node->name)
+	{
+		hub_free(node);
+		return NULL;
+	}
+
+	node->is_dir = is_dir;
+	node->parent = p->parent;
+
+	/* Appended in document order, so a listing comes out the way the peer
+	   wrote it rather than reversed. */
+	if (p->last)
+		p->last->next = node;
+	else if (p->parent)
+		p->parent->children = node;
+	else
+		p->list->root = node;
+
+	p->last = node;
+	p->list->count++;
+	return node;
+}
+
+static void fl_free_nodes(struct fs_filelist_node* node)
+{
+	while (node)
+	{
+		struct fs_filelist_node* next = node->next;
+
+		fl_free_nodes(node->children);
+		hub_free(node->name);
+		hub_free(node);
+		node = next;
+	}
+}
+
+/** Skip to the end of the current tag. @return 1 if it was self-closing. */
+static int fl_skip_tag(struct fl_parser* p)
+{
+	int self_closing = 0;
+
+	while (!fl_eof(p) && p->data[p->pos] != '>')
+	{
+		if (p->data[p->pos] == '/')
+			self_closing = 1;
+		p->pos++;
+	}
+
+	if (!fl_eof(p))
+		p->pos++;
+
+	return self_closing;
+}
+
+/** Read the tag name at the current position into @p out. */
+static void fl_read_tag_name(struct fl_parser* p, char* out, size_t size)
+{
+	size_t n = 0;
+
+	while (!fl_eof(p) && (isalnum((unsigned char) p->data[p->pos]) ||
+	                      p->data[p->pos] == '_' || p->data[p->pos] == '-' ||
+	                      p->data[p->pos] == ':'))
+	{
+		if (n + 1 < size)
+			out[n++] = p->data[p->pos];
+		p->pos++;
+	}
+
+	out[n] = '\0';
+}
+
+static int fl_parse_file(struct fl_parser* p)
+{
+	char name[512];
+	char value[512];
+	char file_name[FS_FILELIST_NAME_MAX * 4 + 1];
+	char tth[MAX_CID_LEN + 1];
+	uint64_t size = 0;
+	int have_name = 0;
+
+	file_name[0] = '\0';
+	tth[0] = '\0';
+
+	for (;;)
+	{
+		fl_skip_space(p);
+
+		if (fl_eof(p))
+			return 0;
+
+		if (p->data[p->pos] == '/' || p->data[p->pos] == '>')
+			break;
+
+		if (!fl_read_attribute(p, name, sizeof(name), value, sizeof(value)))
+			return 0;
+
+		if (strcmp(name, "Name") == 0)
+		{
+			snprintf(file_name, sizeof(file_name), "%s", value);
+			have_name = 1;
+		}
+		else if (strcmp(name, "Size") == 0)
+		{
+			char* end = NULL;
+			errno = 0;
+			size = strtoull(value, &end, 10);
+			if (!end || *end != '\0' || errno == ERANGE)
+				size = 0;
+		}
+		else if (strcmp(name, "TTH") == 0)
+		{
+			if (strlen(value) == MAX_CID_LEN)
+			{
+				size_t i;
+				int ok = 1;
+
+				for (i = 0; i < MAX_CID_LEN; i++)
+					if (!is_valid_base32_char(value[i]))
+						ok = 0;
+
+				if (ok)
+					memcpy(tth, value, MAX_CID_LEN + 1);
+			}
+		}
+	}
+
+	fl_skip_tag(p);
+
+	/*
+	 * A file with no name cannot be listed and a file with no hash cannot be
+	 * fetched, so neither is kept. Skipping it is not an error: a list may
+	 * hold anything, and one unusable entry is no reason to lose the rest.
+	 */
+	if (have_name && *tth)
+	{
+		struct fs_filelist_node* node = fl_new_node(p, file_name, 0);
+		if (node)
+		{
+			node->size = size;
+			memcpy(node->tth, tth, sizeof(node->tth));
+		}
+	}
+
+	return 1;
+}
+
+static int fl_parse_directory_open(struct fl_parser* p, struct fs_filelist_node** out,
+                                   int* self_closing)
+{
+	char name[512];
+	char value[512];
+	char dir_name[FS_FILELIST_NAME_MAX * 4 + 1];
+	int have_name = 0;
+
+	dir_name[0] = '\0';
+	*out = NULL;
+
+	for (;;)
+	{
+		fl_skip_space(p);
+
+		if (fl_eof(p))
+			return 0;
+
+		if (p->data[p->pos] == '/' || p->data[p->pos] == '>')
+			break;
+
+		if (!fl_read_attribute(p, name, sizeof(name), value, sizeof(value)))
+			return 0;
+
+		if (strcmp(name, "Name") == 0)
+		{
+			snprintf(dir_name, sizeof(dir_name), "%s", value);
+			have_name = 1;
+		}
+	}
+
+	*self_closing = fl_skip_tag(p);
+
+	if (have_name)
+		*out = fl_new_node(p, dir_name, 1);
+
+	return 1;
+}
+
+struct fs_filelist* fs_filelist_parse(const char* data, size_t len)
+{
+	struct fl_parser p;
+	struct fs_filelist* list;
+
+	/* Where the walk came from, so a </Directory> can go back up without
+	   recursion: a list is attacker-supplied and its nesting must not decide
+	   how much stack this uses. */
+	struct fs_filelist_node* stack[FS_FILELIST_MAX_DEPTH];
+	struct fs_filelist_node* last_stack[FS_FILELIST_MAX_DEPTH];
+
+	if (!data || !len || len > FS_FILELIST_MAX)
+		return NULL;
+
+	list = (struct fs_filelist*) hub_malloc_zero(sizeof(struct fs_filelist));
+	if (!list)
+		return NULL;
+
+	memset(&p, 0, sizeof(p));
+	p.data = data;
+	p.len = len;
+	p.list = list;
+
+	while (!fl_eof(&p))
+	{
+		char tag[64];
+
+		/* Anything that is not a tag is text between tags, which a file list
+		   has no use for. */
+		if (p.data[p.pos] != '<')
+		{
+			p.pos++;
+			continue;
+		}
+
+		p.pos++;
+
+		if (fl_eof(&p))
+			break;
+
+		/* <?xml ... ?>, <!-- ... -->, <!DOCTYPE ...>: stepped over, never
+		   interpreted. A DOCTYPE in particular is where an XML parser would
+		   start reading things it was not given. */
+		if (p.data[p.pos] == '?' || p.data[p.pos] == '!')
+		{
+			fl_skip_tag(&p);
+			continue;
+		}
+
+		if (p.data[p.pos] == '/')
+		{
+			p.pos++;
+			fl_read_tag_name(&p, tag, sizeof(tag));
+			fl_skip_tag(&p);
+
+			if (strcmp(tag, "Directory") == 0 && p.depth > 0)
+			{
+				p.depth--;
+				p.parent = stack[p.depth];
+				p.last = last_stack[p.depth];
+			}
+			continue;
+		}
+
+		fl_read_tag_name(&p, tag, sizeof(tag));
+
+		if (strcmp(tag, "File") == 0)
+		{
+			if (!fl_parse_file(&p))
+				break;
+		}
+		else if (strcmp(tag, "Directory") == 0)
+		{
+			struct fs_filelist_node* node = NULL;
+			int self_closing = 0;
+
+			if (!fl_parse_directory_open(&p, &node, &self_closing))
+				break;
+
+			if (self_closing || !node)
+				continue;   /* An empty directory, or one we could not name. */
+
+			if (p.depth >= FS_FILELIST_MAX_DEPTH)
+			{
+				LOG_DEBUG("filelist: refusing a list nested deeper than %d", FS_FILELIST_MAX_DEPTH);
+				fl_free_nodes(list->root);
+				hub_free(list);
+				return NULL;
+			}
+
+			stack[p.depth] = p.parent;
+			last_stack[p.depth] = p.last;
+			p.depth++;
+
+			p.parent = node;
+			p.last = NULL;
+		}
+		else
+		{
+			fl_skip_tag(&p);
+		}
+	}
+
+	return list;
+}
+
+struct fs_filelist* fs_filelist_load(const void* bz2, size_t len)
+{
+	struct fs_filelist* list;
+	size_t plain_len = 0;
+	char* plain = fs_filelist_decompress(bz2, len, &plain_len);
+
+	if (!plain)
+		return NULL;
+
+	list = fs_filelist_parse(plain, plain_len);
+	hub_free(plain);
+	return list;
+}
+
+void fs_filelist_destroy(struct fs_filelist* list)
+{
+	if (!list)
+		return;
+
+	fl_free_nodes(list->root);
+	hub_free(list);
+}
+
+struct fs_filelist_node* fs_filelist_root(struct fs_filelist* list)
+{
+	return list ? list->root : NULL;
+}
+
+size_t fs_filelist_count(struct fs_filelist* list)
+{
+	return list ? list->count : 0;
+}
+
+struct fs_filelist_node* fs_filelist_lookup(struct fs_filelist* list, const char* path)
+{
+	struct fs_filelist_node* node;
+	const char* pos;
+
+	if (!list || !path)
+		return NULL;
+
+	node = list->root;
+	pos = path;
+
+	while (*pos && node)
+	{
+		const char* end = strchr(pos, '/');
+		size_t len = end ? (size_t) (end - pos) : strlen(pos);
+		struct fs_filelist_node* found = NULL;
+
+		if (!len)
+			return NULL;   /* An empty component is not a path. */
+
+		for (; node; node = node->next)
+		{
+			if (strlen(node->name) == len && memcmp(node->name, pos, len) == 0)
+			{
+				found = node;
+				break;
+			}
+		}
+
+		if (!found)
+			return NULL;
+
+		if (!end || !end[1])
+			return found;
+
+		if (!found->is_dir)
+			return NULL;   /* Something below a file: there is nothing there. */
+
+		node = found->children;
+		pos = end + 1;
+	}
+
+	return NULL;
+}

--- a/src/fuse/filelist.h
+++ b/src/fuse/filelist.h
@@ -1,0 +1,133 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAVE_UHUB_FUSE_FILELIST_H
+#define HAVE_UHUB_FUSE_FILELIST_H
+
+#include "system.h"
+#include "adc/adctypes.h"
+
+/**
+ * What a peer says it is sharing.
+ *
+ * ADC has no directory listing of its own: a client that wants to see somebody
+ * else's share downloads their *file list*, which is an XML document,
+ * bzip2-compressed, named "files.xml.bz2". It is the same document every
+ * Direct Connect client has produced since DC++ defined it:
+ *
+ *   <FileListing Version="1" CID="..." Base="/" Generator="DC++ 0.868">
+ *     <Directory Name="Music">
+ *       <File Name="song.flac" Size="41234567" TTH="ZP2X...Q"/>
+ *     </Directory>
+ *   </FileListing>
+ *
+ * The interesting part of each File is its TTH: a name in a listing is only a
+ * label, and the hash is what a download actually asks for. So a parsed list is
+ * how a path under users/<cid>/files/ becomes something by-tth could have
+ * fetched.
+ *
+ * EVERY BYTE HERE IS UNTRUSTED. It arrives over a connection anybody can open,
+ * from a peer with no obligation to be truthful or even well-formed, and the
+ * names in it become path components in a mounted filesystem. The parser is
+ * therefore bounded in every direction -- depth, node count, name length,
+ * decompressed size -- and refuses rather than repairs. See fs_filelist_parse().
+ */
+
+/** Largest decompressed file list accepted, in bytes. */
+#define FS_FILELIST_MAX (64 * 1024 * 1024)
+
+/** Deepest nesting accepted. Beyond this a list is refused, not truncated. */
+#define FS_FILELIST_MAX_DEPTH 64
+
+/** Most entries accepted in one list. */
+#define FS_FILELIST_MAX_NODES 500000
+
+/** Longest single name accepted, in bytes. */
+#define FS_FILELIST_NAME_MAX 255
+
+struct fs_filelist;
+
+/** One entry: a directory with children, or a file with a hash. */
+struct fs_filelist_node
+{
+	char* name;
+	int is_dir;
+	uint64_t size;                     /** Files only. */
+	char tth[MAX_CID_LEN + 1];         /** Files only; "" when the peer sent none. */
+
+	struct fs_filelist_node* children; /** Directories only. */
+	struct fs_filelist_node* next;     /** Next entry in the same directory. */
+	struct fs_filelist_node* parent;
+};
+
+/**
+ * Parse a decompressed file list.
+ *
+ * @param data the XML. Need not be NUL terminated.
+ * @param len  its length.
+ * @return the parsed list, or NULL if it is not one. Free with
+ *         fs_filelist_destroy().
+ */
+extern struct fs_filelist* fs_filelist_parse(const char* data, size_t len);
+
+/**
+ * Decompress a bzip2'd file list and parse it.
+ *
+ * @return the parsed list, or NULL if it does not decompress, is larger than
+ *         FS_FILELIST_MAX, or does not parse.
+ */
+extern struct fs_filelist* fs_filelist_load(const void* bz2, size_t len);
+
+extern void fs_filelist_destroy(struct fs_filelist* list);
+
+/** The root directory's first child. */
+extern struct fs_filelist_node* fs_filelist_root(struct fs_filelist* list);
+
+/** How many entries the list holds, directories included. */
+extern size_t fs_filelist_count(struct fs_filelist* list);
+
+/**
+ * Find the entry at @p path, which is relative and uses '/' separators.
+ *
+ * An empty path is the root, which has no node of its own -- use
+ * fs_filelist_root() to list it. @return NULL if there is no such entry.
+ */
+extern struct fs_filelist_node* fs_filelist_lookup(struct fs_filelist* list, const char* path);
+
+/**
+ * Decompress a bzip2 stream into a newly allocated buffer.
+ *
+ * Exposed for the tests. @param out_len receives the length.
+ * @return the buffer, to be released with hub_free(), or NULL.
+ */
+extern char* fs_filelist_decompress(const void* data, size_t len, size_t* out_len);
+
+/**
+ * Make one name from a file list safe to use as a path component.
+ *
+ * A name in a list is whatever the peer put there: it may hold a slash, be
+ * empty, be "." or "..", or be a control character away from being unprintable.
+ * Any of those would either escape the directory it is in or be unusable, so
+ * they are replaced or refused here -- never passed through.
+ *
+ * @return 1 if @p name yielded a usable component in @p buf.
+ */
+extern int fs_filelist_safe_name(const char* name, char* buf, size_t size);
+
+#endif /* HAVE_UHUB_FUSE_FILELIST_H */

--- a/src/fuse/fs.c
+++ b/src/fuse/fs.c
@@ -1,0 +1,1403 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fuse/fs.h"
+#include "fuse/bridge.h"
+#include "fuse/chatlog.h"
+#include "fuse/filelist.h"
+#include "fuse/stream.h"
+#include "fuse/transfer.h"
+#include "fuse/nodes.h"
+#include "fuse/render.h"
+#include "fuse/roster.h"
+#include "fuse/session.h"
+#include "util/memory.h"
+
+/*
+ * The kernel side of the mount.
+ *
+ * Every function in here runs on a FUSE thread and may touch nothing but the
+ * path it was handed: hub state is reached by submitting a task to the ADC
+ * thread and waiting for it. The pattern is the same each time -- resolve the
+ * path (pure, no hub involved), pack the operation into a struct that embeds a
+ * struct fs_task, submit, return the result.
+ *
+ * A metadata file is snapshotted at open() and read() serves the snapshot, so
+ * a read never crosses threads and never sees a value change underneath it.
+ */
+
+/**
+ * What an open descriptor holds.
+ *
+ * A metadata file is a snapshot taken at open(); a chat file is a stream read
+ * live by offset; a message file collects what is written to it until a line
+ * is complete. One struct covers all three because a chat file is both of the
+ * first two at once -- it can be read and written on the same descriptor.
+ */
+struct fs_handle
+{
+	enum fs_node_type type;
+	char cid[MAX_CID_LEN + 1];
+
+	char* snapshot;         /** Metadata files: the bytes read() serves. */
+	size_t snapshot_size;
+
+	char* pending;          /** Written bytes not yet ending in a newline. */
+	size_t pending_len;
+
+	/* by-tth: an open descriptor into the cache, and the pin that keeps the
+	   file there for as long as it is held. */
+	int fd;
+	uint64_t file_size;
+	char tth[MAX_CID_LEN + 1];
+
+	/* Or, for a file too large to hold, the window it is read through. */
+	struct fs_stream* stream;
+};
+
+/* Defined with the readlink operation below; getattr needs a symlink's length
+   and that is the same string. */
+static int readlink_target(struct fs_session* session, const char* name, char* buf, size_t size);
+
+static struct fs_session* g_session = NULL;
+
+void fs_set_session(struct fs_session* session)
+{
+	g_session = session;
+
+	/* How a waiter finds out its reader has gone away. Told to the bridge
+	   rather than called from it, so bridge.c needs to know nothing about
+	   libfuse. */
+	if (session)
+		fs_bridge_set_interrupt_check(session->bridge, fuse_interrupted);
+}
+
+static struct fs_session* current_session(void)
+{
+	return g_session;
+}
+
+static void stat_dir(struct stat* st, time_t when, nlink_t links)
+{
+	st->st_mode = S_IFDIR | 0555;
+	st->st_nlink = links;
+	st->st_mtime = st->st_ctime = st->st_atime = when;
+}
+
+static void stat_file(struct stat* st, time_t when, mode_t mode, off_t size)
+{
+	st->st_mode = S_IFREG | mode;
+	st->st_nlink = 1;
+	st->st_size = size;
+	st->st_mtime = st->st_ctime = st->st_atime = when;
+}
+
+/* --------------------------------------------------- a peer's shared files */
+
+/**
+ * Everything under users/<cid>/files needs that user's file list first, and
+ * fetching one takes as long as a download does. So each such operation is two
+ * tasks on one struct: the first makes sure the list is here (parking if it is
+ * not), the second does the work now that it is.
+ */
+struct task_files
+{
+	struct fs_task task;
+	const struct fs_node* node;
+
+	/* Stage two fills in whichever of these the operation wanted. */
+	struct stat* st;
+	void* buf;
+	fuse_fill_dir_t filler;
+	char tth[MAX_CID_LEN + 1];
+	uint64_t size;
+};
+
+static int run_files_fetch(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_files* op = (struct task_files*) task;
+
+	if (!session->transfer)
+		return -ENOENT;
+
+	if (!fs_roster_by_cid(session->roster, op->node->cid))
+		return -ENOENT;
+
+	return fs_transfer_want_filelist(session->transfer, op->node->cid, task);
+}
+
+static int run_files_abandon(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+
+	if (session->transfer)
+		fs_transfer_abandon(session->transfer, task);
+
+	return 0;
+}
+
+/** The entry a files/ path names, or NULL for the files/ directory itself. */
+static struct fs_filelist_node* files_lookup(struct fs_session* session,
+                                             const struct fs_node* node,
+                                             struct fs_filelist** out_list)
+{
+	struct fs_filelist* list = fs_transfer_filelist(session->transfer, node->cid);
+
+	if (out_list)
+		*out_list = list;
+
+	if (!list)
+		return NULL;
+
+	if (node->type == FS_NODE_USER_FILES_DIR)
+		return NULL;
+
+	return fs_filelist_lookup(list, node->tail);
+}
+
+static int run_files_getattr(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_files* op = (struct task_files*) task;
+	struct fs_filelist* list = NULL;
+	struct fs_filelist_node* entry;
+	struct fs_roster_user* user = fs_roster_by_cid(session->roster, op->node->cid);
+	time_t when = user ? user->since : session->mounted;
+
+	entry = files_lookup(session, op->node, &list);
+
+	if (op->node->type == FS_NODE_USER_FILES_DIR)
+	{
+		if (!list)
+			return -ENOENT;
+
+		stat_dir(op->st, when, 2);
+		return 0;
+	}
+
+	if (!entry)
+		return -ENOENT;
+
+	if (entry->is_dir)
+		stat_dir(op->st, when, 2);
+	else
+		stat_file(op->st, when, 0444, (off_t) entry->size);
+
+	return 0;
+}
+
+static int run_files_readdir(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_files* op = (struct task_files*) task;
+	struct fs_filelist* list = NULL;
+	struct fs_filelist_node* entry;
+
+	if (op->node->type == FS_NODE_USER_FILES_DIR)
+	{
+		struct fs_filelist* root_list = fs_transfer_filelist(session->transfer, op->node->cid);
+
+		if (!root_list)
+			return -ENOENT;
+
+		entry = fs_filelist_root(root_list);
+	}
+	else
+	{
+		struct fs_filelist_node* node = files_lookup(session, op->node, &list);
+
+		if (!node)
+			return -ENOENT;
+
+		if (!node->is_dir)
+			return -ENOTDIR;
+
+		entry = node->children;
+	}
+
+	op->filler(op->buf, ".", NULL, 0, 0);
+	op->filler(op->buf, "..", NULL, 0, 0);
+
+	for (; entry; entry = entry->next)
+		op->filler(op->buf, entry->name, NULL, 0, 0);
+
+	return 0;
+}
+
+/** Resolve a files/ path to the hash a download would ask for. */
+static int run_files_resolve(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_files* op = (struct task_files*) task;
+	struct fs_filelist_node* entry = files_lookup(session, op->node, NULL);
+
+	if (!entry)
+		return -ENOENT;
+
+	if (entry->is_dir)
+		return -EISDIR;
+
+	memcpy(op->tth, entry->tth, sizeof(op->tth));
+	op->size = entry->size;
+	return 0;
+}
+
+/**
+ * Run a files/ operation: fetch the list if needed, then do the work.
+ *
+ * @param op   zeroed by the caller, with whatever the operation needs -- the
+ *             stat to fill in, the directory buffer to fill -- already set.
+ *             This does not clear it: doing so would throw those away.
+ * @param work the stage-two task function.
+ */
+static int files_operation(const struct fs_node* node, struct task_files* op, fs_task_fn work)
+{
+	struct fs_bridge* bridge = current_session()->bridge;
+	int result;
+
+	op->node = node;
+
+	fs_task_init(&op->task, run_files_fetch);
+	op->task.abandon = run_files_abandon;
+
+	result = fs_bridge_submit(bridge, &op->task);
+	if (result < 0)
+		return result;
+
+	fs_task_init(&op->task, work);
+	return fs_bridge_submit(bridge, &op->task);
+}
+
+/* ----------------------------------------------------------------- getattr */
+
+struct task_getattr
+{
+	struct fs_task task;
+	const struct fs_node* node;
+	struct stat* st;
+};
+
+static int run_getattr(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_getattr* op = (struct task_getattr*) task;
+	const struct fs_node* node = op->node;
+	struct fs_roster_user* user = NULL;
+	struct fs_render_ctx ctx;
+	ssize_t size;
+
+	if (node->type == FS_NODE_USER_DIR || node->type == FS_NODE_USER_FILE ||
+	    node->type == FS_NODE_USER_MSG || node->type == FS_NODE_USER_FILES_DIR ||
+	    node->type == FS_NODE_USER_FILES_ENTRY)
+	{
+		user = fs_roster_by_cid(session->roster, node->cid);
+		if (!user)
+			return -ENOENT;
+	}
+
+	switch (node->type)
+	{
+		case FS_NODE_ROOT:
+		case FS_NODE_HUB_DIR:
+		case FS_NODE_ME_DIR:
+		case FS_NODE_CHAT_DIR:
+		case FS_NODE_USERS_DIR:
+		case FS_NODE_BY_NICK_DIR:
+			stat_dir(op->st, session->mounted, 2);
+			return 0;
+
+		/* A stream, so the size is how much has ever been said -- which is
+		   what makes `tail -f` able to follow it. */
+		case FS_NODE_CHAT_MAIN:
+			stat_file(op->st, session->mounted, 0644,
+			          (off_t) fs_chatlog_size(session->chat_main));
+			return 0;
+
+		case FS_NODE_CHAT_PRIVATE:
+			stat_file(op->st, session->mounted, 0444,
+			          (off_t) fs_chatlog_size(session->chat_private));
+			return 0;
+
+		case FS_NODE_USER_DIR:
+			stat_dir(op->st, user->since, 2);
+			return 0;
+
+		/*
+		 * A directory, said without asking anybody. Fetching the list to
+		 * answer a stat would mean `ls -l users/<cid>/` downloaded a share
+		 * list; the list is fetched when the directory is actually listed.
+		 */
+		case FS_NODE_USER_FILES_DIR:
+			if (!session->transfer)
+				return -ENOENT;
+			stat_dir(op->st, user->since, 2);
+			return 0;
+
+		case FS_NODE_HUB_FILE:
+		case FS_NODE_ME_FILE:
+		case FS_NODE_USER_FILE:
+			fs_session_render_ctx(session, &ctx);
+			if (user)
+			{
+				ctx.inf = user->inf;
+				ctx.sid = user->sid;
+				ctx.since = user->since;
+			}
+
+			/* Measured, not guessed: st_size has to agree with what read()
+			   will hand over, or every reader that trusts stat() truncates. */
+			size = fs_render(node, &ctx, NULL, 0);
+			if (size < 0)
+				return -EIO;
+
+			stat_file(op->st, user ? user->since : session->mounted, 0444, size);
+			return 0;
+
+		case FS_NODE_USER_MSG:
+			/* Write-only: there is no such thing as reading a message you
+			   have not sent. */
+			stat_file(op->st, user->since, 0200, 0);
+			return 0;
+
+		case FS_NODE_BY_NICK_LINK:
+		{
+			char target[MAX_CID_LEN + 16];
+			int len = readlink_target(session, node->name, target, sizeof(target));
+
+			if (len < 0)
+				return len;
+
+			op->st->st_mode = S_IFLNK | 0777;
+			op->st->st_nlink = 1;
+			op->st->st_size = len;
+			op->st->st_mtime = op->st->st_ctime = op->st->st_atime = session->mounted;
+			return 0;
+		}
+
+		case FS_NODE_BY_TTH_DIR:
+			stat_dir(op->st, session->mounted, 2);
+			return 0;
+
+		/*
+		 * Content addressed: every hash is a name here, whether or not anybody
+		 * on the hub has the file. The size is known only once it is cached,
+		 * and 0 before that -- so a reader should open it and read rather than
+		 * trust stat(), which is what cat does anyway.
+		 */
+		case FS_NODE_BY_TTH_FILE:
+		{
+			uint64_t size = 0;
+
+			if (!session->transfer)
+				return -ENOENT;
+
+			fs_transfer_peek(session->transfer, op->node->name, &size);
+			stat_file(op->st, session->mounted, 0444, (off_t) size);
+			return 0;
+		}
+
+		/* Resolvable, not yet served: a user's share arrives with the phase
+		   that implements it. Reporting it as absent is the honest answer
+		   until then. */
+		default:
+			return -ENOENT;
+	}
+}
+
+static int fs_getattr(const char* path, struct stat* st, struct fuse_file_info* fi)
+{
+	struct task_getattr op;
+	struct fs_node node;
+
+	(void) fi;
+
+	memset(st, 0, sizeof(*st));
+	st->st_uid = getuid();
+	st->st_gid = getgid();
+
+	if (!fs_node_resolve(path, &node))
+		return -ENOENT;
+
+	/*
+	 * Only a path *below* files/ needs the list. Stat'ing files/ itself must
+	 * not fetch one: `ls -l users/<cid>/` stats every entry in that directory,
+	 * and nobody asking who is online meant to start downloading share lists.
+	 */
+	if (node.type == FS_NODE_USER_FILES_ENTRY)
+	{
+		struct task_files files;
+
+		memset(&files, 0, sizeof(files));
+		files.st = st;
+		return files_operation(&node, &files, run_files_getattr);
+	}
+
+	fs_task_init(&op.task, run_getattr);
+	op.node = &node;
+	op.st = st;
+
+	return fs_bridge_submit(current_session()->bridge, &op.task);
+}
+
+/* ----------------------------------------------------------------- readdir */
+
+struct task_readdir
+{
+	struct fs_task task;
+	const struct fs_node* node;
+	void* buf;
+	fuse_fill_dir_t filler;
+};
+
+static void fill(struct task_readdir* op, const char* name)
+{
+	/* The FUSE thread is blocked inside fs_bridge_submit() for the duration,
+	   so its buffer has exactly one writer even though this is the other
+	   thread doing the writing. */
+	op->filler(op->buf, name, NULL, 0, 0);
+}
+
+static void fill_fields(struct task_readdir* op, const struct fs_field* table)
+{
+	size_t n;
+
+	for (n = 0; table[n].name; n++)
+		fill(op, table[n].name);
+}
+
+static int fill_name(void* ptr, const char* name, struct fs_roster_user* user)
+{
+	(void) user;
+	fill((struct task_readdir*) ptr, name);
+	return 0;
+}
+
+static int run_readdir(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_readdir* op = (struct task_readdir*) task;
+	struct fs_roster_user* user;
+
+	fill(op, ".");
+	fill(op, "..");
+
+	switch (op->node->type)
+	{
+		case FS_NODE_ROOT:
+			fill(op, "hub");
+			fill(op, "me");
+			fill(op, "chat");
+			fill(op, "users");
+			fill(op, "by-nick");
+			if (session->transfer)
+				fill(op, "by-tth");
+			return 0;
+
+		case FS_NODE_CHAT_DIR:
+			fill(op, "main");
+			fill(op, "private");
+			return 0;
+
+		/*
+		 * Deliberately empty. A content addressed directory has no listing:
+		 * there is no set of hashes to enumerate, only the one you already
+		 * know. Listing what happens to be cached would suggest otherwise.
+		 */
+		case FS_NODE_BY_TTH_DIR:
+			return 0;
+
+		case FS_NODE_HUB_DIR:
+			fill_fields(op, fs_hub_fields);
+			return 0;
+
+		case FS_NODE_ME_DIR:
+			fill_fields(op, fs_me_fields);
+			return 0;
+
+		case FS_NODE_USERS_DIR:
+			for (user = fs_roster_first(session->roster); user; user = fs_roster_next(session->roster))
+				fill(op, user->cid);
+			return 0;
+
+		case FS_NODE_USER_DIR:
+			if (!fs_roster_by_cid(session->roster, op->node->cid))
+				return -ENOENT;
+			fill_fields(op, fs_user_fields);
+			if (session->transfer)
+				fill(op, "files");
+			return 0;
+
+		case FS_NODE_BY_NICK_DIR:
+			fs_roster_walk_names(session->roster, fill_name, op);
+			return 0;
+
+		default:
+			return -ENOENT;
+	}
+}
+
+static int fs_readdir(const char* path, void* buf, fuse_fill_dir_t filler, off_t offset,
+                      struct fuse_file_info* fi, enum fuse_readdir_flags flags)
+{
+	struct task_readdir op;
+	struct fs_node node;
+
+	(void) offset;
+	(void) fi;
+	(void) flags;
+
+	if (!fs_node_resolve(path, &node))
+		return -ENOENT;
+
+	/* Listing a share is where the file list is actually needed, and where the
+	   wait for it belongs. */
+	if (node.type == FS_NODE_USER_FILES_DIR || node.type == FS_NODE_USER_FILES_ENTRY)
+	{
+		struct task_files files;
+
+		memset(&files, 0, sizeof(files));
+		files.buf = buf;
+		files.filler = filler;
+		return files_operation(&node, &files, run_files_readdir);
+	}
+
+	fs_task_init(&op.task, run_readdir);
+	op.node = &node;
+	op.buf = buf;
+	op.filler = filler;
+
+	return fs_bridge_submit(current_session()->bridge, &op.task);
+}
+
+/* -------------------------------------------------------------- open / read */
+
+struct task_open
+{
+	struct fs_task task;
+	const struct fs_node* node;
+	struct fs_handle* handle;
+};
+
+static int run_open(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_open* op = (struct task_open*) task;
+	struct fs_roster_user* user = NULL;
+	struct fs_render_ctx ctx;
+	ssize_t size;
+
+	if (op->node->type == FS_NODE_USER_FILE)
+	{
+		user = fs_roster_by_cid(session->roster, op->node->cid);
+		if (!user)
+			return -ENOENT;
+	}
+
+	fs_session_render_ctx(session, &ctx);
+	if (user)
+	{
+		ctx.inf = user->inf;
+		ctx.sid = user->sid;
+		ctx.since = user->since;
+	}
+
+	size = fs_render(op->node, &ctx, NULL, 0);
+	if (size < 0)
+		return -EIO;
+
+	op->handle->snapshot = (char*) hub_malloc((size_t) size + 1);
+	if (!op->handle->snapshot)
+		return -ENOMEM;
+
+	if (fs_render(op->node, &ctx, op->handle->snapshot, (size_t) size + 1) != size)
+	{
+		hub_free(op->handle->snapshot);
+		op->handle->snapshot = NULL;
+		return -EIO;
+	}
+
+	op->handle->snapshot_size = (size_t) size;
+	return 0;
+}
+
+/**
+ * Fetch a hash, then open it.
+ *
+ * Two stages on the same task. The first runs on the ADC thread and usually
+ * parks: the content has to be asked for, and a peer takes as long as it takes.
+ * The second runs once the answer is in, and turns the cached file into a
+ * descriptor the reader can use. They are separate because between them the
+ * FUSE thread is asleep and the ADC thread is doing other work.
+ */
+struct task_tth_open
+{
+	struct fs_task task;
+	const char* tth;
+
+	/** Whose share it came out of, when it came out of one. */
+	const char* from_cid;
+
+	struct fs_handle* handle;
+};
+
+/** Detach this reader from the want queue; the ADC thread's side of a ^C. */
+static int run_tth_abandon(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+
+	if (session->transfer)
+		fs_transfer_abandon(session->transfer, task);
+
+	return 0;
+}
+
+static int run_tth_open(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_tth_open* op = (struct task_tth_open*) task;
+
+	if (!session->transfer)
+		return -ENOENT;
+
+	return fs_transfer_want_from(session->transfer, op->tth, op->from_cid, task);
+}
+
+/** The second stage: the content is cached, so open it and hold it there. */
+static int run_tth_attach(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_tth_open* op = (struct task_tth_open*) task;
+	int fd;
+
+	if (!session->transfer)
+		return -ENOENT;
+
+	fd = fs_transfer_open_file(session->transfer, op->tth, &op->handle->file_size);
+	if (fd < 0)
+		return fd;
+
+	op->handle->fd = fd;
+	return 0;
+}
+
+struct task_tth_close
+{
+	struct fs_task task;
+	const char* tth;
+	int fd;
+};
+
+static int run_tth_close(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_tth_close* op = (struct task_tth_close*) task;
+
+	if (session->transfer)
+		fs_transfer_close_file(session->transfer, op->tth, op->fd);
+
+	return 0;
+}
+
+/* --- reading a file too large to hold ------------------------------------ */
+
+struct task_stream_open
+{
+	struct fs_task task;
+	struct fs_handle* handle;
+	uint64_t size;
+};
+
+static int run_stream_open(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_stream_open* op = (struct task_stream_open*) task;
+
+	if (!session->transfer)
+		return -ENOENT;
+
+	/* Only above the ceiling. Everything that can be fetched whole still is,
+	   because only that path can check what arrived against its hash. */
+	if (op->size <= fs_transfer_max_cached_size(session->transfer))
+		return 0;
+
+	op->handle->stream = fs_transfer_stream_open(session->transfer, op->handle->tth,
+	                                             op->handle->cid, op->size);
+	return op->handle->stream ? 0 : -ENFILE;
+}
+
+struct task_stream_read
+{
+	struct fs_task task;
+	struct fs_stream* stream;
+	uint64_t offset;
+	void* buf;
+	size_t len;
+
+	int done;   /** The read finished; @c got is how much of it there was. */
+	int got;
+};
+
+static int run_stream_read(void* ptr, struct fs_task* task)
+{
+	struct task_stream_read* op = (struct task_stream_read*) task;
+	int result;
+
+	(void) ptr;
+
+	result = fs_stream_read(op->stream, op->offset, op->buf, op->len, task, &op->got);
+
+	if (result == 0)
+		op->done = 1;
+
+	return result;
+}
+
+static int run_stream_abandon(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+
+	if (session->transfer)
+		fs_transfer_abandon(session->transfer, task);
+
+	return 0;
+}
+
+struct task_stream_close
+{
+	struct fs_task task;
+	struct fs_stream* stream;
+};
+
+static int run_stream_close(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_stream_close* op = (struct task_stream_close*) task;
+
+	if (session->transfer)
+		fs_transfer_stream_close(session->transfer, op->stream);
+
+	return 0;
+}
+
+/** Does the user this path names still exist? Nothing else to check. */
+struct task_user_exists
+{
+	struct fs_task task;
+	const char* cid;
+};
+
+static int run_user_exists(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_user_exists* op = (struct task_user_exists*) task;
+
+	return fs_roster_by_cid(session->roster, op->cid) ? 0 : -ENOENT;
+}
+
+static int fs_open(const char* path, struct fuse_file_info* fi)
+{
+	struct fs_handle* handle;
+	struct fs_node node;
+	int writable;
+	int result;
+
+	if (!fs_node_resolve(path, &node))
+		return -ENOENT;
+
+	writable = (node.type == FS_NODE_CHAT_MAIN || node.type == FS_NODE_USER_MSG);
+
+	switch (node.type)
+	{
+		case FS_NODE_HUB_FILE:
+		case FS_NODE_ME_FILE:
+		case FS_NODE_USER_FILE:
+		case FS_NODE_CHAT_MAIN:
+		case FS_NODE_CHAT_PRIVATE:
+		case FS_NODE_USER_MSG:
+		case FS_NODE_BY_TTH_FILE:
+		case FS_NODE_USER_FILES_ENTRY:
+			break;
+
+		default:
+			return -ENOENT;
+	}
+
+	if ((fi->flags & O_ACCMODE) != O_RDONLY && !writable)
+		return -EACCES;
+
+	/* Write-only, so there is nothing to hand back to a reader. */
+	if ((fi->flags & O_ACCMODE) != O_WRONLY && node.type == FS_NODE_USER_MSG)
+		return -EACCES;
+
+	handle = (struct fs_handle*) hub_malloc_zero(sizeof(struct fs_handle));
+	if (!handle)
+		return -ENOMEM;
+
+	handle->type = node.type;
+	handle->fd = -1;
+	memcpy(handle->cid, node.cid, sizeof(handle->cid));
+	/* Only a by-tth node names a hash, and a hash is exactly MAX_CID_LEN
+	   characters; node.name is the wider buffer because a nick can be longer,
+	   and anything that does not fit here was never a hash. */
+	if (node.type == FS_NODE_BY_TTH_FILE)
+		memcpy(handle->tth, node.name, sizeof(handle->tth));
+
+	/*
+	 * A shared file is by-tth wearing a name. The list says which hash the path
+	 * stands for; from there it is the same fetch, the same cache and the same
+	 * descriptor -- which is also why a file already fetched by hash opens
+	 * instantly under its name.
+	 */
+	if (node.type == FS_NODE_USER_FILES_ENTRY)
+	{
+		struct task_files files;
+
+		memset(&files, 0, sizeof(files));
+		result = files_operation(&node, &files, run_files_resolve);
+
+		/*
+		 * Too big to fetch whole: read it through a window instead. The size
+		 * comes from the owner's file list, so this decision is made before a
+		 * single byte has been asked for -- which is the point, since fetching
+		 * it whole is exactly what must not happen.
+		 */
+		if (result == 0 && files.size > 0)
+		{
+			struct task_stream_open sop;
+
+			memcpy(handle->tth, files.tth, sizeof(handle->tth));
+
+			fs_task_init(&sop.task, run_stream_open);
+			sop.handle = handle;
+			sop.size = files.size;
+
+			result = fs_bridge_submit(current_session()->bridge, &sop.task);
+
+			if (result >= 0 && handle->stream)
+			{
+				handle->file_size = files.size;
+				goto opened;
+			}
+
+			if (result < 0)
+			{
+				hub_free(handle);
+				return result;
+			}
+		}
+
+		if (result == 0)
+		{
+			struct task_tth_open op;
+
+			memcpy(handle->tth, files.tth, sizeof(handle->tth));
+
+			fs_task_init(&op.task, run_tth_open);
+			op.task.abandon = run_tth_abandon;
+			op.tth = handle->tth;
+			op.from_cid = handle->cid;   /* whose share this path is in */
+			op.handle = handle;
+
+			result = fs_bridge_submit(current_session()->bridge, &op.task);
+
+			if (result == 0)
+			{
+				fs_task_init(&op.task, run_tth_attach);
+				result = fs_bridge_submit(current_session()->bridge, &op.task);
+			}
+		}
+	}
+	else if (node.type == FS_NODE_USER_MSG)
+	{
+		/* Nothing to render, but an open on a user who is not here must still
+		   fail -- otherwise the message goes nowhere and nobody is told. */
+		struct task_user_exists check;
+
+		fs_task_init(&check.task, run_user_exists);
+		check.cid = handle->cid;
+		result = fs_bridge_submit(current_session()->bridge, &check.task);
+	}
+	else if (node.type == FS_NODE_BY_TTH_FILE)
+	{
+		struct task_tth_open op;
+
+		fs_task_init(&op.task, run_tth_open);
+		op.task.abandon = run_tth_abandon;
+		op.tth = handle->tth;
+		op.from_cid = NULL;   /* by-tth names no owner: the hub is asked. */
+		op.handle = handle;
+
+		/* Blocks for as long as the fetch takes -- which is the point: an
+		   open() that returned before the bytes existed would only move the
+		   waiting to the first read, where there is nowhere to report a peer
+		   that never answered. */
+		result = fs_bridge_submit(current_session()->bridge, &op.task);
+
+		if (result == 0)
+		{
+			fs_task_init(&op.task, run_tth_attach);
+			result = fs_bridge_submit(current_session()->bridge, &op.task);
+		}
+	}
+	else if (node.type == FS_NODE_CHAT_MAIN || node.type == FS_NODE_CHAT_PRIVATE)
+	{
+		/* A stream: read() goes to the log itself, at whatever offset the
+		   reader has got to, so there is nothing to snapshot. */
+		result = 0;
+	}
+	else
+	{
+		struct task_open op;
+
+		fs_task_init(&op.task, run_open);
+		op.node = &node;
+		op.handle = handle;
+		result = fs_bridge_submit(current_session()->bridge, &op.task);
+	}
+
+	if (result < 0)
+	{
+		hub_free(handle->snapshot);
+		hub_free(handle);
+		return result;
+	}
+
+opened:
+	/*
+	 * The kernel must not answer a read out of what it thinks it knows about
+	 * these files. A by-tth file has no size until it has been fetched, so the
+	 * getattr that preceded this open said zero -- and against a cached size of
+	 * zero the kernel returns EOF without ever calling read(). A chat file is a
+	 * stream that grows between one read and the next, which the page cache
+	 * would likewise hold stale.
+	 *
+	 * direct_io turns both off: every read reaches this filesystem, and the
+	 * size in stat() goes back to being what it is for a growing file --
+	 * information rather than a limit.
+	 */
+	if (node.type == FS_NODE_BY_TTH_FILE || node.type == FS_NODE_USER_FILES_ENTRY ||
+	    node.type == FS_NODE_CHAT_MAIN || node.type == FS_NODE_CHAT_PRIVATE)
+		fi->direct_io = 1;
+
+	fi->fh = (uint64_t) (uintptr_t) handle;
+	return 0;
+}
+
+/* ------------------------------------------------------------------ read */
+
+struct task_chat_read
+{
+	struct fs_task task;
+	int private_log;
+	uint64_t offset;
+	char* buf;
+	size_t size;
+	size_t got;
+};
+
+static int run_chat_read(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_chat_read* op = (struct task_chat_read*) task;
+
+	op->got = fs_chatlog_read(op->private_log ? session->chat_private : session->chat_main,
+	                          op->offset, op->buf, op->size);
+	return 0;
+}
+
+static int fs_read(const char* path, char* buf, size_t size, off_t offset,
+                   struct fuse_file_info* fi)
+{
+	struct fs_handle* handle = (struct fs_handle*) (uintptr_t) fi->fh;
+
+	(void) path;
+
+	if (!handle || offset < 0)
+		return -EBADF;
+
+	if (handle->type == FS_NODE_CHAT_MAIN || handle->type == FS_NODE_CHAT_PRIVATE)
+	{
+		struct task_chat_read op;
+		int result;
+
+		fs_task_init(&op.task, run_chat_read);
+		op.private_log = (handle->type == FS_NODE_CHAT_PRIVATE);
+		op.offset = (uint64_t) offset;
+		op.buf = buf;
+		op.size = size;
+		op.got = 0;
+
+		result = fs_bridge_submit(current_session()->bridge, &op.task);
+		return (result < 0) ? result : (int) op.got;
+	}
+
+	if (handle->stream)
+	{
+		/*
+		 * A read may have to fetch, and a fetch may have to be waited for --
+		 * possibly more than once, since the window it asks for is not always
+		 * the window the reader ends up needing. Waking with 0 means "the
+		 * window moved, look again", so this loops rather than returning it.
+		 */
+		struct task_stream_read op;
+
+		memset(&op, 0, sizeof(op));
+		op.stream = handle->stream;
+		op.offset = (uint64_t) offset;
+		op.buf = buf;
+		op.len = size;
+
+		for (;;)
+		{
+			int result;
+
+			op.done = 0;
+			fs_task_init(&op.task, run_stream_read);
+			op.task.abandon = run_stream_abandon;
+
+			result = fs_bridge_submit(current_session()->bridge, &op.task);
+
+			if (result < 0)
+				return result;
+
+			if (op.done)
+				return op.got;
+
+			/* Woken because the window moved: read it again. */
+		}
+	}
+
+	if (handle->type == FS_NODE_BY_TTH_FILE || handle->type == FS_NODE_USER_FILES_ENTRY)
+	{
+		ssize_t got;
+
+		if (handle->fd < 0)
+			return -EBADF;
+
+		/* Straight to the file, on this thread: see fs_transfer_read(). */
+		got = fs_transfer_read(current_session()->transfer, handle->fd, handle->file_size,
+		                       (uint64_t) offset, buf, size);
+		return (got < 0) ? -EIO : (int) got;
+	}
+
+	if (!handle->snapshot)
+		return -EBADF;
+
+	if ((size_t) offset >= handle->snapshot_size)
+		return 0;
+
+	if (size > handle->snapshot_size - (size_t) offset)
+		size = handle->snapshot_size - (size_t) offset;
+
+	memcpy(buf, &handle->snapshot[offset], size);
+	return (int) size;
+}
+
+/* ----------------------------------------------------------------- write */
+
+struct task_send
+{
+	struct fs_task task;
+	enum fs_node_type type;
+	const char* cid;
+	const char* text;
+};
+
+static int run_send(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_send* op = (struct task_send*) task;
+
+	if (op->type == FS_NODE_USER_MSG)
+		return fs_session_send_pm(session, op->cid, op->text);
+
+	return fs_session_send_chat(session, op->text);
+}
+
+/** Hand one complete message to the ADC thread. */
+static int handle_send(struct fs_handle* handle, const char* text)
+{
+	struct task_send op;
+
+	fs_task_init(&op.task, run_send);
+	op.type = handle->type;
+	op.cid = handle->cid;
+	op.text = text;
+
+	return fs_bridge_submit(current_session()->bridge, &op.task);
+}
+
+/** Send whatever has been collected, and start again. */
+static int handle_flush(struct fs_handle* handle)
+{
+	int result;
+
+	if (!handle->pending || !handle->pending_len)
+		return 0;
+
+	handle->pending[handle->pending_len] = '\0';
+	handle->pending_len = 0;
+
+	result = handle_send(handle, handle->pending);
+	return result;
+}
+
+static int fs_write(const char* path, const char* buf, size_t size, off_t offset,
+                    struct fuse_file_info* fi)
+{
+	struct fs_handle* handle = (struct fs_handle*) (uintptr_t) fi->fh;
+	size_t n;
+
+	(void) path;
+	(void) offset;   /* A message is not a byte at a position. */
+
+	if (!handle)
+		return -EBADF;
+
+	if (handle->type != FS_NODE_CHAT_MAIN && handle->type != FS_NODE_USER_MSG)
+		return -EACCES;
+
+	if (!handle->pending)
+	{
+		handle->pending = (char*) hub_malloc(FS_CHAT_MAX + 1);
+		if (!handle->pending)
+			return -ENOMEM;
+	}
+
+	/*
+	 * A write is not a message: `echo` delivers one line with its newline, a
+	 * program writing in chunks delivers a fraction of one, and a here-document
+	 * delivers several at once. So bytes are collected and a message is sent
+	 * for each newline -- and for whatever is left when the descriptor is
+	 * closed, which is what makes `echo -n` work.
+	 */
+	for (n = 0; n < size; n++)
+	{
+		if (buf[n] == '\n')
+		{
+			int result = handle_flush(handle);
+			if (result < 0)
+				return result;
+			continue;
+		}
+
+		if (handle->pending_len >= FS_CHAT_MAX)
+		{
+			/* Drop the oversized line rather than send a truncated one: the
+			   hub would refuse it anyway, and half a message is worse than
+			   none. */
+			handle->pending_len = 0;
+			return -EMSGSIZE;
+		}
+
+		handle->pending[handle->pending_len++] = buf[n];
+	}
+
+	return (int) size;
+}
+
+/**
+ * Accept a truncation without doing anything.
+ *
+ * `> chat/main` opens with O_TRUNC, and refusing that would make the ordinary
+ * way of writing to a file in a shell fail. There is nothing to truncate: what
+ * has already been said cannot be unsaid, and the log is a record rather than
+ * a file.
+ */
+static int fs_truncate(const char* path, off_t size, struct fuse_file_info* fi)
+{
+	struct fs_node node;
+
+	(void) size;
+	(void) fi;
+
+	if (!fs_node_resolve(path, &node))
+		return -ENOENT;
+
+	if (node.type != FS_NODE_CHAT_MAIN && node.type != FS_NODE_USER_MSG)
+		return -EACCES;
+
+	return 0;
+}
+
+static int fs_release(const char* path, struct fuse_file_info* fi)
+{
+	struct fs_handle* handle = (struct fs_handle*) (uintptr_t) fi->fh;
+
+	(void) path;
+
+	if (handle)
+	{
+		/* Anything written without a closing newline is a message too. */
+		handle_flush(handle);
+
+		if (handle->stream)
+		{
+			struct task_stream_close op;
+
+			fs_task_init(&op.task, run_stream_close);
+			op.stream = handle->stream;
+			fs_bridge_submit(current_session()->bridge, &op.task);
+			handle->stream = NULL;
+		}
+
+		if (handle->fd >= 0)
+		{
+			struct task_tth_close op;
+
+			fs_task_init(&op.task, run_tth_close);
+			op.tth = handle->tth;
+			op.fd = handle->fd;
+			fs_bridge_submit(current_session()->bridge, &op.task);
+		}
+
+		hub_free(handle->snapshot);
+		hub_free(handle->pending);
+		hub_free(handle);
+		fi->fh = 0;
+	}
+
+	return 0;
+}
+
+/* ---------------------------------------------------------------- readlink */
+
+struct name_match
+{
+	const char* wanted;
+	char cid[MAX_CID_LEN + 1];
+	int found;
+};
+
+static int match_name(void* ptr, const char* name, struct fs_roster_user* user)
+{
+	struct name_match* match = (struct name_match*) ptr;
+
+	if (strcmp(name, match->wanted) != 0)
+		return 0;
+
+	memcpy(match->cid, user->cid, sizeof(match->cid));
+	match->found = 1;
+	return 1;
+}
+
+static int readlink_target(struct fs_session* session, const char* name, char* buf, size_t size)
+{
+	struct name_match match;
+	int len;
+
+	match.wanted = name;
+	match.found = 0;
+	match.cid[0] = '\0';
+
+	fs_roster_walk_names(session->roster, match_name, &match);
+
+	if (!match.found)
+		return -ENOENT;
+
+	len = snprintf(buf, size, "../users/%s", match.cid);
+	if (len < 0 || (size_t) len >= size)
+		return -ENAMETOOLONG;
+
+	return len;
+}
+
+struct task_readlink
+{
+	struct fs_task task;
+	const struct fs_node* node;
+	char* buf;
+	size_t size;
+};
+
+static int run_readlink(void* ptr, struct fs_task* task)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+	struct task_readlink* op = (struct task_readlink*) task;
+	int len = readlink_target(session, op->node->name, op->buf, op->size);
+
+	return (len < 0) ? len : 0;
+}
+
+static int fs_readlink(const char* path, char* buf, size_t size)
+{
+	struct task_readlink op;
+	struct fs_node node;
+
+	if (!fs_node_resolve(path, &node))
+		return -ENOENT;
+
+	if (node.type != FS_NODE_BY_NICK_LINK)
+		return -EINVAL;
+
+	if (!size)
+		return -EINVAL;
+
+	fs_task_init(&op.task, run_readlink);
+	op.node = &node;
+	op.buf = buf;
+	op.size = size;
+
+	return fs_bridge_submit(current_session()->bridge, &op.task);
+}
+
+/* --------------------------------------------------------------------------- */
+
+/**
+ * Turn the kernel's caches off.
+ *
+ * Everything here changes without the filesystem being told: a user's INF is
+ * replaced, somebody leaves, the chat grows, and a by-tth file goes from "no
+ * such size" to its real one the moment it has been fetched. With the default
+ * one second attribute cache, a stat() taken before a download would still be
+ * answered from afterwards -- and a size of zero cached that way makes the
+ * kernel return EOF without ever asking this filesystem to read.
+ *
+ * The cost is a round trip per stat, on a filesystem whose files are a few
+ * bytes each and whose directories are held in memory. Correctness is worth
+ * more than that here.
+ */
+static void* fs_init(struct fuse_conn_info* conn, struct fuse_config* cfg)
+{
+	(void) conn;
+
+	cfg->attr_timeout = 0;
+	cfg->entry_timeout = 0;
+	cfg->negative_timeout = 0;
+
+	return NULL;
+}
+
+static const struct fuse_operations fs_operations = {
+	.init     = fs_init,
+	.getattr  = fs_getattr,
+	.readdir  = fs_readdir,
+	.readlink = fs_readlink,
+	.open     = fs_open,
+	.read     = fs_read,
+	.write    = fs_write,
+	.truncate = fs_truncate,
+	.release  = fs_release,
+};
+
+const struct fuse_operations* fs_get_operations(void)
+{
+	return &fs_operations;
+}

--- a/src/fuse/fs.h
+++ b/src/fuse/fs.h
@@ -1,0 +1,45 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAVE_UHUB_FUSE_FS_H
+#define HAVE_UHUB_FUSE_FS_H
+
+/* The API this is written against. libfuse's headers refuse to compile without
+   it, and it must be set before <fuse.h> is included anywhere. */
+#define FUSE_USE_VERSION 31
+#include <fuse.h>
+#include <fuse_lowlevel.h>
+
+#include "system.h"
+
+struct fs_session;
+
+/** The operation table, for main() to hand to fuse_new(). */
+extern const struct fuse_operations* fs_get_operations(void);
+
+/**
+ * Name the session the operations work against.
+ *
+ * Not fuse_new()'s user_data: the session cannot exist that early. It is built
+ * after fuse_daemonize(), because a thread does not survive the fork, and by
+ * then fuse_new() has long returned. One mount per process, so one session.
+ */
+extern void fs_set_session(struct fs_session* session);
+
+#endif /* HAVE_UHUB_FUSE_FS_H */

--- a/src/fuse/main.c
+++ b/src/fuse/main.c
@@ -1,0 +1,302 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fuse/config.h"
+#include "fuse/fs.h"
+#include "fuse/transfer.h"
+#include "fuse/session.h"
+#include "network/network.h"
+#include "util/log.h"
+#include "util/memory.h"
+#include "util/threads.h"
+#include "version.h"
+
+/*
+ * uhub-fuse: an ADC hub, mounted.
+ *
+ * Two threads. This one ends up inside fuse_main(), which owns the process's
+ * signal handling and does not return until the filesystem is unmounted. The
+ * other runs uhub's event loop and owns every piece of hub state there is; see
+ * fuse/bridge.h for how the two meet.
+ *
+ * The event loop is started before fuse_main() rather than from an init()
+ * callback, so that a hub which refuses the login has somewhere to report it
+ * other than a mounted, empty directory.
+ */
+
+struct fs_options
+{
+	char* config;
+	char* address;
+	char* nick;
+	char* password;
+};
+
+static struct fs_options options;
+
+#define FS_OPT(t, p) { t, offsetof(struct fs_options, p), 1 }
+
+static const struct fuse_opt option_spec[] = {
+	FS_OPT("--config=%s",   config),
+	FS_OPT("--hub=%s",      address),
+	FS_OPT("--nick=%s",     nick),
+	FS_OPT("--password=%s", password),
+	FUSE_OPT_END
+};
+
+static void usage(const char* program)
+{
+	printf("Usage: %s --hub=adc[s]://host:port [options] <mountpoint>\n\n", program);
+	printf("uhub-fuse options:\n");
+	printf("    --config=FILE          read the settings below from FILE instead.\n");
+	printf("                           Keep the password there, not on the command\n");
+	printf("                           line, and chmod 600 it\n");
+	printf("    --hub=URL              the hub to mount. Use adcs:// for TLS, and\n");
+	printf("                           adcs://host:port/?kp=SHA256/<base32> to pin\n");
+	printf("                           the hub's certificate\n");
+	printf("    --nick=NAME            the nick to log in with (default: uhub-fuse)\n");
+	printf("    --password=SECRET      the password, for a registered account. Every\n");
+	printf("                           user on this machine can read it out of ps;\n");
+	printf("                           prefer --config\n");
+	printf("\n");
+	printf("The mount holds hub/ (what the hub says about itself), me/, users/ (one\n");
+	printf("directory per user, named by CID) and by-nick/ (symlinks into users/).\n");
+	printf("\n");
+}
+
+/** The ADC thread: uhub's event loop, and everything it owns. */
+static void* session_thread(void* ptr)
+{
+	struct fs_session* session = (struct fs_session*) ptr;
+
+	fs_session_run(session);
+	return NULL;
+}
+
+int main(int argc, char** argv)
+{
+	struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
+	struct fuse_cmdline_opts opts;
+	struct fs_session* session = NULL;
+	struct fs_config config;
+	struct fuse* fuse = NULL;
+	uhub_thread_t* thread = NULL;
+	int mounted = 0;
+	int handlers = 0;
+	int result = 1;
+	int loop_result;
+
+	memset(&options, 0, sizeof(options));
+	memset(&opts, 0, sizeof(opts));
+	memset(&config, 0, sizeof(config));
+
+	if (fuse_opt_parse(&args, &options, option_spec, NULL) == -1)
+		return 1;
+
+	/*
+	 * The FUSE_USE_VERSION 31 spelling of fuse_loop_mt() takes no thread
+	 * configuration, so its idle thread count stays at the UINT_MAX default
+	 * that libfuse >= 3.12 warns about on every start. The mount option is the
+	 * only way to set it at this API version. Inserted at the front so an -o
+	 * the caller passes is parsed later and still wins.
+	 *
+	 * Staying on 31 is deliberate: the configuration API arrived in libfuse
+	 * 3.12, and several distributions that are current still ship 3.10.
+	 */
+	fuse_opt_insert_arg(&args, 1, "-o");
+	fuse_opt_insert_arg(&args, 2, "max_idle_threads=10");
+
+	if (fuse_parse_cmdline(&args, &opts) != 0)
+		return 1;
+
+	if (opts.show_help)
+	{
+		usage(argv[0]);
+		fuse_cmdline_help();
+		fuse_lib_help(&args);
+		result = 0;
+		goto cleanup;
+	}
+
+	if (opts.show_version)
+	{
+		printf("uhub-fuse %s\n", VERSION);
+		fuse_lowlevel_version();
+		result = 0;
+		goto cleanup;
+	}
+
+	if (!opts.mountpoint)
+	{
+		fprintf(stderr, "%s: no mountpoint given. See --help.\n", argv[0]);
+		goto cleanup;
+	}
+
+	/*
+	 * The file first, then the command line over it: an operator who keeps a
+	 * password in a 0600 file must still be able to point the same file at a
+	 * different hub for one run.
+	 */
+	fs_config_defaults(&config);
+
+	if (options.config && !fs_config_read(options.config, &config))
+		goto cleanup;
+
+	if (options.address && !fs_config_set(&config, "hub", options.address))
+		goto cleanup;
+
+	if (options.nick && !fs_config_set(&config, "nick", options.nick))
+		goto cleanup;
+
+	if (options.password)
+	{
+		if (!fs_config_set(&config, "password", options.password))
+			goto cleanup;
+
+		/* Said once, plainly. The value is in argv either way by the time we
+		   are running, so this is a warning and not a refusal. */
+		fprintf(stderr, "%s: --password is visible to every user on this machine "
+		                "in ps; use --config with a file chmod 600.\n", argv[0]);
+	}
+
+	if (!config.address || !*config.address)
+	{
+		fprintf(stderr, "%s: no hub given. Use --hub=adc://host:port or a config "
+		                "file, or --help.\n", argv[0]);
+		goto cleanup;
+	}
+
+	fuse = fuse_new(&args, fs_get_operations(), sizeof(struct fuse_operations), NULL);
+	if (!fuse)
+		goto cleanup;
+
+	if (fuse_mount(fuse, opts.mountpoint) != 0)
+		goto cleanup;
+	mounted = 1;
+
+	/*
+	 * Everything above this line runs in the process that was started;
+	 * everything below may run in a forked child. fuse_daemonize() is the
+	 * fork, and a thread does not survive one -- the child would come up with
+	 * a mounted filesystem, no event loop behind it, and every operation
+	 * blocking for ever. So the hub session is built and started here, after
+	 * the fork, and not before it.
+	 */
+	if (fuse_daemonize(opts.foreground) != 0)
+		goto cleanup;
+
+	/*
+	 * In the foreground, say what is happening: a mount that is fetching a
+	 * file from somebody has nowhere else to report progress, and INFO is
+	 * where those messages are. Daemonized, keep to what an operator would
+	 * want in a log.
+	 */
+	hub_set_log_verbosity(opts.foreground ? 5 : 4);
+	net_initialize();
+
+	session = fs_session_create(&config);
+	if (!session)
+	{
+		fprintf(stderr, "%s: unable to create the hub session.\n", argv[0]);
+		goto cleanup;
+	}
+
+	/*
+	 * A mount without a transfer port still works; it just cannot fetch
+	 * anything, so by-tth is empty. Worth a warning rather than a refusal --
+	 * the port may be taken by a second mount, and reading the user list is
+	 * the greater part of what this is for.
+	 */
+	fs_session_set_transfer(session, fs_transfer_create(session, &config));
+
+	fs_set_session(session);
+
+	fs_session_start(session);
+
+	thread = uhub_thread_create(session_thread, session);
+	if (!thread)
+	{
+		fprintf(stderr, "%s: unable to start the hub thread.\n", argv[0]);
+		goto cleanup;
+	}
+
+	if (fuse_set_signal_handlers(fuse_get_session(fuse)) != 0)
+		goto cleanup;
+	handlers = 1;
+
+	if (opts.singlethread)
+	{
+		loop_result = fuse_loop(fuse);
+	}
+	else
+	{
+		loop_result = fuse_loop_mt(fuse, opts.clone_fd);
+	}
+
+	/*
+	 * The loop reports three things in one int: 0 for the unmount, a negative
+	 * errno for a failure, and -- easy to mistake for one -- a *positive*
+	 * signal number when it was terminated by a signal. Both of the first and
+	 * last are a shutdown that did what it was asked, and an init system that
+	 * saw SIGTERM answered with a non-zero status would record every clean
+	 * stop as a crash.
+	 */
+	result = (loop_result < 0) ? 1 : 0;
+
+cleanup:
+	if (session)
+		fs_session_stop(session);
+
+	if (thread)
+		uhub_thread_join(thread);
+
+	if (handlers)
+		fuse_remove_signal_handlers(fuse_get_session(fuse));
+
+	if (mounted)
+		fuse_unmount(fuse);
+
+	if (fuse)
+		fuse_destroy(fuse);
+
+	if (session)
+	{
+		fs_session_destroy(session);
+		net_destroy();
+	}
+
+	fs_config_free(&config);
+
+	free(opts.mountpoint);
+	fuse_opt_free_args(&args);
+
+	hub_free(options.config);
+	hub_free(options.address);
+	hub_free(options.nick);
+
+	/* fuse_opt_parse() strdup'd it out of argv; the copy goes now, even though
+	   the original is still there for anyone reading ps. */
+	if (options.password)
+	{
+		memset(options.password, 0, strlen(options.password));
+		hub_free(options.password);
+	}
+
+	return result;
+}

--- a/src/fuse/nodes.c
+++ b/src/fuse/nodes.c
@@ -1,0 +1,394 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fuse/nodes.h"
+#include "adc/adcconst.h"
+#include "util/misc.h"
+
+const struct fs_field fs_hub_fields[] = {
+	{ "state",       NULL,                     FS_FIELD_READ },
+	{ "name",        NULL,                     FS_FIELD_READ },
+	{ "description", NULL,                     FS_FIELD_READ },
+	{ "version",     NULL,                     FS_FIELD_READ },
+	{ "address",     NULL,                     FS_FIELD_READ },
+	{ "support",     NULL,                     FS_FIELD_READ },
+	{ "users",       NULL,                     FS_FIELD_READ | FS_FIELD_NUMERIC },
+	{ "sid",         NULL,                     FS_FIELD_READ },
+	{ "tls",         NULL,                     FS_FIELD_READ },
+	{ NULL,          NULL,                     0 }
+};
+
+const struct fs_field fs_me_fields[] = {
+	{ "nick",        NULL, FS_FIELD_READ },
+	{ "cid",         NULL, FS_FIELD_READ },
+	{ "sid",         NULL, FS_FIELD_READ },
+	{ "support",     NULL, FS_FIELD_READ },
+	{ NULL,          NULL, 0 }
+};
+
+const struct fs_field fs_user_fields[] = {
+	{ "nick",         ADC_INF_FLAG_NICK,               FS_FIELD_READ },
+	{ "description",  ADC_INF_FLAG_DESCRIPTION,        FS_FIELD_READ },
+	{ "share_size",   ADC_INF_FLAG_SHARED_SIZE,        FS_FIELD_READ | FS_FIELD_NUMERIC },
+	{ "shared_files", ADC_INF_FLAG_SHARED_FILES,       FS_FIELD_READ | FS_FIELD_NUMERIC },
+	{ "slots",        ADC_INF_FLAG_UPLOAD_SLOTS,       FS_FIELD_READ | FS_FIELD_NUMERIC },
+	{ "ip",           NULL,                            FS_FIELD_READ },
+	{ "user_agent",   ADC_INF_FLAG_USER_AGENT_PRODUCT, FS_FIELD_READ },
+	{ "version",      ADC_INF_FLAG_USER_AGENT_VERSION, FS_FIELD_READ },
+	{ "client_type",  ADC_INF_FLAG_CLIENT_TYPE,        FS_FIELD_READ | FS_FIELD_NUMERIC },
+	{ "support",      ADC_INF_FLAG_SUPPORT,            FS_FIELD_READ },
+	{ "sid",          NULL,                            FS_FIELD_READ },
+	{ "connected",    NULL,                            FS_FIELD_READ },
+	{ "inf",          NULL,                            FS_FIELD_READ | FS_FIELD_RAW_INF },
+	{ "msg",          NULL,                            FS_FIELD_WRITE },
+	{ NULL,           NULL,                            0 }
+};
+
+const struct fs_field* fs_field_lookup(const struct fs_field* table, const char* name)
+{
+	size_t n;
+
+	if (!table || !name)
+		return NULL;
+
+	for (n = 0; table[n].name; n++)
+		if (strcmp(table[n].name, name) == 0)
+			return &table[n];
+
+	return NULL;
+}
+
+int fs_is_base32_hash(const char* name)
+{
+	size_t n;
+
+	if (!name)
+		return 0;
+
+	for (n = 0; n < MAX_CID_LEN; n++)
+		if (!name[n] || !is_valid_base32_char(name[n]))
+			return 0;
+
+	return name[MAX_CID_LEN] == '\0';
+}
+
+size_t fs_sanitize_nick(const char* nick, char* buf, size_t size)
+{
+	size_t n = 0;
+
+	if (!buf || !size)
+		return 0;
+
+	if (nick)
+	{
+		for (; nick[n] && n + 1 < size; n++)
+		{
+			unsigned char c = (unsigned char) nick[n];
+
+			/* A path separator, a control character or DEL would either split
+			   the name in two or render as a hole in a terminal. Bytes >= 0x80
+			   are left alone: a nick is UTF-8 and so is the mount. */
+			if (c == '/' || c < 0x20 || c == 0x7f)
+				buf[n] = '_';
+			else
+				buf[n] = (char) c;
+		}
+	}
+	buf[n] = '\0';
+
+	/* "" cannot be a name at all, and "." and ".." already mean something. */
+	if (n == 0 || strcmp(buf, ".") == 0 || strcmp(buf, "..") == 0)
+	{
+		n = (size > 4) ? 4 : size - 1;
+		memcpy(buf, "user", n);
+		buf[n] = '\0';
+	}
+
+	return n;
+}
+
+/* -------------------------------------------------------------- path walking */
+
+struct path_iter
+{
+	const char* p;   /** At a '/' separator, or at the terminating NUL. */
+	int bad;         /** An empty, "." or ".." component was seen. */
+};
+
+/**
+ * Take the next component.
+ *
+ * A trailing slash ends the walk ("/hub/" is "/hub"); an embedded empty
+ * component, "." or ".." sets @c bad and ends it. @return 1 on success.
+ */
+static int path_next(struct path_iter* it, const char** out, size_t* len)
+{
+	const char* s = it->p;
+	const char* e;
+
+	if (it->bad || !s || *s != '/')
+		return 0;
+
+	s++;
+	if (*s == '\0')
+	{
+		it->p = s;
+		return 0;
+	}
+
+	if (*s == '/')
+	{
+		it->bad = 1;
+		return 0;
+	}
+
+	e = strchr(s, '/');
+	if (!e)
+		e = s + strlen(s);
+
+	if ((e - s) == 1 && s[0] == '.')
+	{
+		it->bad = 1;
+		return 0;
+	}
+
+	if ((e - s) == 2 && s[0] == '.' && s[1] == '.')
+	{
+		it->bad = 1;
+		return 0;
+	}
+
+	*out = s;
+	*len = (size_t) (e - s);
+	it->p = e;
+	return 1;
+}
+
+/** Is @p comp, which is not NUL terminated, equal to @p str? */
+static int comp_is(const char* comp, size_t len, const char* str)
+{
+	return strlen(str) == len && memcmp(comp, str, len) == 0;
+}
+
+/**
+ * Copy a component out, refusing one that does not fit.
+ * @return 1 on success.
+ */
+static int comp_copy(const char* comp, size_t len, char* buf, size_t size)
+{
+	if (len >= size)
+		return 0;
+
+	memcpy(buf, comp, len);
+	buf[len] = '\0';
+	return 1;
+}
+
+/** Walk what is left, so a bad component anywhere in it is refused. */
+static int path_tail_ok(struct path_iter* it)
+{
+	const char* comp;
+	size_t len;
+
+	while (path_next(it, &comp, &len))
+		; /* nothing: path_next does the checking */
+
+	return !it->bad;
+}
+
+/* Everything below files/ resolves to one node type; the difference is only
+   whether there is anything below it at all. */
+static void resolve_user_files(struct path_iter* it, struct fs_node* out)
+{
+	const char* tail = it->p;
+
+	if (*tail == '\0' || (tail[0] == '/' && tail[1] == '\0'))
+	{
+		out->type = FS_NODE_USER_FILES_DIR;
+		return;
+	}
+
+	if (!path_tail_ok(it))
+		return;
+
+	out->type = FS_NODE_USER_FILES_ENTRY;
+	out->tail = tail + 1;
+}
+
+static void resolve_user(struct path_iter* it, struct fs_node* out)
+{
+	const struct fs_field* field;
+	const char* comp;
+	size_t len;
+	char name[MAX_NICK_LEN + 1];
+
+	if (!path_next(it, &comp, &len))
+	{
+		if (!it->bad)
+			out->type = FS_NODE_USER_DIR;
+		return;
+	}
+
+	if (comp_is(comp, len, "files"))
+	{
+		resolve_user_files(it, out);
+		return;
+	}
+
+	if (!comp_copy(comp, len, name, sizeof(name)))
+		return;
+
+	/* Nothing may follow a metadata file. */
+	if (path_next(it, &comp, &len) || it->bad)
+		return;
+
+	field = fs_field_lookup(fs_user_fields, name);
+	if (!field)
+		return;
+
+	out->field = field;
+	out->type = (field->flags & FS_FIELD_WRITE) ? FS_NODE_USER_MSG : FS_NODE_USER_FILE;
+}
+
+/** hub/ and me/: a directory of metadata files and nothing else. */
+static void resolve_field_dir(struct path_iter* it, struct fs_node* out,
+                              const struct fs_field* table,
+                              enum fs_node_type dir_type, enum fs_node_type file_type)
+{
+	const struct fs_field* field;
+	const char* comp;
+	size_t len;
+	char name[MAX_NICK_LEN + 1];
+
+	if (!path_next(it, &comp, &len))
+	{
+		if (!it->bad)
+			out->type = dir_type;
+		return;
+	}
+
+	if (!comp_copy(comp, len, name, sizeof(name)))
+		return;
+
+	if (path_next(it, &comp, &len) || it->bad)
+		return;
+
+	field = fs_field_lookup(table, name);
+	if (!field)
+		return;
+
+	out->field = field;
+	out->type = file_type;
+}
+
+int fs_node_resolve(const char* path, struct fs_node* out)
+{
+	struct path_iter it;
+	const char* comp;
+	size_t len;
+
+	if (!out)
+		return 0;
+
+	memset(out, 0, sizeof(*out));
+
+	if (!path || path[0] != '/')
+		return 0;
+
+	it.p = path;
+	it.bad = 0;
+
+	if (!path_next(&it, &comp, &len))
+	{
+		if (!it.bad)
+			out->type = FS_NODE_ROOT;
+		return out->type != FS_NODE_NONE;
+	}
+
+	if (comp_is(comp, len, "hub"))
+	{
+		resolve_field_dir(&it, out, fs_hub_fields, FS_NODE_HUB_DIR, FS_NODE_HUB_FILE);
+	}
+	else if (comp_is(comp, len, "me"))
+	{
+		resolve_field_dir(&it, out, fs_me_fields, FS_NODE_ME_DIR, FS_NODE_ME_FILE);
+	}
+	else if (comp_is(comp, len, "chat"))
+	{
+		if (!path_next(&it, &comp, &len))
+		{
+			if (!it.bad)
+				out->type = FS_NODE_CHAT_DIR;
+		}
+		else if (comp_is(comp, len, "main") && !path_next(&it, &comp, &len) && !it.bad)
+		{
+			out->type = FS_NODE_CHAT_MAIN;
+		}
+		else if (comp_is(comp, len, "private") && !path_next(&it, &comp, &len) && !it.bad)
+		{
+			out->type = FS_NODE_CHAT_PRIVATE;
+		}
+	}
+	else if (comp_is(comp, len, "users"))
+	{
+		if (!path_next(&it, &comp, &len))
+		{
+			if (!it.bad)
+				out->type = FS_NODE_USERS_DIR;
+		}
+		else if (comp_copy(comp, len, out->cid, sizeof(out->cid)) && fs_is_base32_hash(out->cid))
+		{
+			resolve_user(&it, out);
+		}
+	}
+	else if (comp_is(comp, len, "by-nick"))
+	{
+		if (!path_next(&it, &comp, &len))
+		{
+			if (!it.bad)
+				out->type = FS_NODE_BY_NICK_DIR;
+		}
+		else if (comp_copy(comp, len, out->name, sizeof(out->name)))
+		{
+			if (!path_next(&it, &comp, &len) && !it.bad)
+				out->type = FS_NODE_BY_NICK_LINK;
+		}
+	}
+	else if (comp_is(comp, len, "by-tth"))
+	{
+		if (!path_next(&it, &comp, &len))
+		{
+			if (!it.bad)
+				out->type = FS_NODE_BY_TTH_DIR;
+		}
+		else if (comp_copy(comp, len, out->name, sizeof(out->name)) && fs_is_base32_hash(out->name))
+		{
+			if (!path_next(&it, &comp, &len) && !it.bad)
+				out->type = FS_NODE_BY_TTH_FILE;
+		}
+	}
+
+	if (out->type == FS_NODE_NONE)
+	{
+		memset(out, 0, sizeof(*out));
+		return 0;
+	}
+
+	return 1;
+}

--- a/src/fuse/nodes.h
+++ b/src/fuse/nodes.h
@@ -1,0 +1,167 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAVE_UHUB_FUSE_NODES_H
+#define HAVE_UHUB_FUSE_NODES_H
+
+#include "system.h"
+#include "adc/adctypes.h"
+
+/**
+ * The shape of the mount, and nothing else.
+ *
+ * This module answers one question -- "what kind of thing could this path be?"
+ * -- and answers it without consulting the hub. A path naming a user resolves
+ * whether or not that user is online: the CID is checked for the syntax of a
+ * CID and no more. Existence is the roster's business and is decided on the
+ * ADC thread, where the roster lives; deciding it here would mean taking the
+ * hub lock inside every path parse.
+ *
+ * Everything in here is therefore pure: no allocation, no I/O, no globals.
+ *
+ * The tree:
+ *
+ *   /                        FS_NODE_ROOT
+ *   /hub/                    FS_NODE_HUB_DIR       fields: fs_hub_fields
+ *   /me/                     FS_NODE_ME_DIR        fields: fs_me_fields
+ *   /chat/main               FS_NODE_CHAT_MAIN     read: log, write: send
+ *   /chat/private            FS_NODE_CHAT_PRIVATE  private messages, read only
+ *   /users/<cid>/            FS_NODE_USER_DIR      fields: fs_user_fields
+ *   /users/<cid>/files/...   FS_NODE_USER_FILES_*  (not yet served)
+ *   /by-nick/<nick>          FS_NODE_BY_NICK_LINK  symlink to ../users/<cid>
+ *   /by-tth/<tth>            FS_NODE_BY_TTH_FILE   (not yet served)
+ */
+
+enum fs_node_type
+{
+	FS_NODE_NONE = 0,          /** No such path. Nothing else in the node is set. */
+	FS_NODE_ROOT,
+	FS_NODE_HUB_DIR,
+	FS_NODE_HUB_FILE,
+	FS_NODE_ME_DIR,
+	FS_NODE_ME_FILE,
+	FS_NODE_CHAT_DIR,
+	FS_NODE_CHAT_MAIN,
+	FS_NODE_CHAT_PRIVATE,
+	FS_NODE_USERS_DIR,
+	FS_NODE_USER_DIR,
+	FS_NODE_USER_FILE,
+	FS_NODE_USER_MSG,
+	FS_NODE_USER_FILES_DIR,    /** /users/<cid>/files */
+	FS_NODE_USER_FILES_ENTRY,  /** something below it; @c tail is the remainder */
+	FS_NODE_BY_NICK_DIR,
+	FS_NODE_BY_NICK_LINK,
+	FS_NODE_BY_TTH_DIR,
+	FS_NODE_BY_TTH_FILE,
+};
+
+/** Properties of one metadata file. */
+enum fs_field_flags
+{
+	FS_FIELD_READ    = 0x01,  /** Contents can be read. */
+	FS_FIELD_WRITE   = 0x02,  /** Writing to it does something. */
+	FS_FIELD_RAW_INF = 0x04,  /** The whole stored INF line, not one argument. */
+	FS_FIELD_NUMERIC = 0x08,  /** Absent means zero, not absent. */
+};
+
+/**
+ * One file inside hub/, me/ or a user directory.
+ *
+ * @c inf names the two-letter ADC INF argument the contents come from, or is
+ * NULL for a file the renderer synthesises (the SID, the connect time, the raw
+ * line). The value in an INF is escaped, so a reader of @c inf must unescape
+ * it -- see fs_render_field(), which is the only intended reader.
+ */
+struct fs_field
+{
+	const char* name;
+	const char* inf;
+	unsigned int flags;
+};
+
+/**
+ * The three field tables, each terminated by an entry with a NULL name.
+ * They are the readdir listing for their directory as well as its lookup
+ * table, so the order here is the order the files appear in.
+ */
+extern const struct fs_field fs_hub_fields[];
+extern const struct fs_field fs_me_fields[];
+extern const struct fs_field fs_user_fields[];
+
+/** Look @p name up in a table. @return the field, or NULL. */
+extern const struct fs_field* fs_field_lookup(const struct fs_field* table, const char* name);
+
+/** A resolved path. Which members are set depends on @c type. */
+struct fs_node
+{
+	enum fs_node_type type;
+
+	/** FS_NODE_USER_*: the CID out of the path. */
+	char cid[MAX_CID_LEN + 1];
+
+	/** FS_NODE_BY_NICK_LINK: the link name. FS_NODE_BY_TTH_FILE: the hash. */
+	char name[MAX_NICK_LEN + 1];
+
+	/** FS_NODE_{HUB,ME,USER}_FILE: which file. */
+	const struct fs_field* field;
+
+	/**
+	 * FS_NODE_USER_FILES_ENTRY: the path below files/, without a leading
+	 * slash. It points into the caller's @p path and lives exactly as long.
+	 */
+	const char* tail;
+};
+
+/**
+ * Resolve an absolute mount-relative path.
+ *
+ * Pure. A path that cannot be a node in this tree -- an unknown top level, a
+ * CID that is not 39 base32 characters, a metadata file that is not in the
+ * table -- yields FS_NODE_NONE, which is the caller's ENOENT.
+ *
+ * @param path a NUL-terminated path beginning with '/'. Trailing slashes are
+ *             ignored; empty components ("//") are not, and are refused.
+ * @param out  filled in on success, zeroed on failure. Never NULL.
+ * @return 1 when @p out->type is not FS_NODE_NONE.
+ */
+extern int fs_node_resolve(const char* path, struct fs_node* out);
+
+/**
+ * Is @p name a syntactically valid CID or TTH -- 39 base32 characters?
+ *
+ * Both are a 24-byte tiger hash in base32, so this is one test for both, and
+ * it is what makes a CID safe to use as a directory name: the alphabet has no
+ * '/', no NUL and no '.', so "." and ".." cannot be spelled.
+ */
+extern int fs_is_base32_hash(const char* name);
+
+/**
+ * Turn a nick into a name usable in by-nick/.
+ *
+ * A nick is user text and arrives with none of a filename's restrictions: it
+ * may contain a slash, may be "." or "..", and may collide with another user's.
+ * Offending bytes become '_', and a name that would still be unusable falls
+ * back to "user". Collisions are not resolved here -- the caller appends the
+ * SID, which is unique per session, when it finds one.
+ *
+ * @return the number of bytes written, excluding the NUL, or 0 if @p size is 0.
+ */
+extern size_t fs_sanitize_nick(const char* nick, char* buf, size_t size);
+
+#endif /* HAVE_UHUB_FUSE_NODES_H */

--- a/src/fuse/render.c
+++ b/src/fuse/render.c
@@ -1,0 +1,278 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fuse/render.h"
+#include "adc/adcconst.h"
+#include "adc/message.h"
+#include "adc/sid.h"
+#include "util/memory.h"
+
+/*
+ * A rendered file is one INF argument, a timestamp, a number or the raw INF
+ * line, so MAX_ADC_CMD_LEN bounds all of it: the raw line is the largest of
+ * them and cannot be longer than the command that carried it. Unescaping only
+ * ever shortens. The margin covers the newline and the labels.
+ */
+#define RENDER_MAX (MAX_ADC_CMD_LEN + 64)
+
+struct render_buf
+{
+	char data[RENDER_MAX];
+	size_t len;
+	int overflow;
+};
+
+static void put_mem(struct render_buf* out, const char* data, size_t len)
+{
+	if (out->overflow)
+		return;
+
+	if (len > sizeof(out->data) - out->len)
+	{
+		out->overflow = 1;
+		return;
+	}
+
+	memcpy(&out->data[out->len], data, len);
+	out->len += len;
+}
+
+static void put_str(struct render_buf* out, const char* str)
+{
+	if (str)
+		put_mem(out, str, strlen(str));
+}
+
+/** One value, and the newline that makes it a line. */
+static void put_line(struct render_buf* out, const char* str)
+{
+	if (!str)
+		return;
+
+	put_str(out, str);
+	put_mem(out, "\n", 1);
+}
+
+static void put_size(struct render_buf* out, size_t value)
+{
+	char num[32];
+	int len = snprintf(num, sizeof(num), "%llu\n", (unsigned long long) value);
+
+	if (len > 0)
+		put_mem(out, num, (size_t) len);
+}
+
+static void put_sid(struct render_buf* out, sid_t sid)
+{
+	put_line(out, sid_to_string(sid));
+}
+
+/**
+ * One INF argument, unescaped.
+ *
+ * An absent argument is an empty file, or "0" when the field is numeric --
+ * SS, SF, SL and CT are all omitted rather than sent as zero by most clients,
+ * and a reader that has to tell those two spellings apart learns nothing from
+ * having been given the chance.
+ */
+static void put_inf_field(struct render_buf* out, struct adc_message* inf,
+                          const struct fs_field* field)
+{
+	char* escaped;
+	char* value;
+
+	escaped = inf ? adc_msg_get_named_argument(inf, field->inf) : NULL;
+	if (!escaped)
+	{
+		if (field->flags & FS_FIELD_NUMERIC)
+			put_mem(out, "0\n", 2);
+		return;
+	}
+
+	value = adc_msg_unescape(escaped);
+	hub_free(escaped);
+
+	if (!value)
+	{
+		out->overflow = 1;  /* OOM: fail the read rather than truncate it */
+		return;
+	}
+
+	put_line(out, value);
+	hub_free(value);
+}
+
+/** The address the hub observed, which is the only one it relays. */
+static void put_address(struct render_buf* out, struct adc_message* inf)
+{
+	static const char* const flags[] = { ADC_INF_FLAG_IPV4_ADDR, ADC_INF_FLAG_IPV6_ADDR };
+	size_t n;
+
+	if (!inf)
+		return;
+
+	/* A user reached over both families has both, and both are true, so both
+	   are listed -- one per line, in the order v4 then v6. */
+	for (n = 0; n < 2; n++)
+	{
+		char* value = adc_msg_get_named_argument(inf, flags[n]);
+		if (!value)
+			continue;
+
+		put_line(out, value);
+		hub_free(value);
+	}
+}
+
+size_t fs_render_timestamp(time_t when, char* buf, size_t size)
+{
+	struct tm tm;
+
+	if (!buf || !size)
+		return 0;
+
+	if (!gmtime_r(&when, &tm))
+		return 0;
+
+	return strftime(buf, size, "%Y-%m-%dT%H:%M:%SZ", &tm);
+}
+
+static void put_timestamp(struct render_buf* out, time_t when)
+{
+	char stamp[32];
+
+	if (fs_render_timestamp(when, stamp, sizeof(stamp)))
+		put_line(out, stamp);
+}
+
+static void render_hub(struct render_buf* out, const struct fs_render_ctx* ctx,
+                       const struct fs_field* field)
+{
+	if (strcmp(field->name, "state") == 0)
+		put_line(out, ctx->hub_state);
+	else if (strcmp(field->name, "name") == 0)
+		put_line(out, ctx->hub_name);
+	else if (strcmp(field->name, "description") == 0)
+		put_line(out, ctx->hub_description);
+	else if (strcmp(field->name, "version") == 0)
+		put_line(out, ctx->hub_version);
+	else if (strcmp(field->name, "address") == 0)
+		put_line(out, ctx->hub_address);
+	else if (strcmp(field->name, "support") == 0)
+		put_line(out, ctx->hub_support);
+	else if (strcmp(field->name, "users") == 0)
+		put_size(out, ctx->hub_users);
+	else if (strcmp(field->name, "sid") == 0)
+		put_sid(out, ctx->my_sid);
+	else if (strcmp(field->name, "tls") == 0)
+	{
+		/* Not "yes": which version and which cipher is the part an operator
+		   checking a hub actually wants, and "no" is unambiguous without them. */
+		if (!ctx->tls_version)
+			put_line(out, "no");
+		else
+		{
+			put_str(out, ctx->tls_version);
+			if (ctx->tls_cipher)
+			{
+				put_mem(out, " ", 1);
+				put_str(out, ctx->tls_cipher);
+			}
+			put_mem(out, "\n", 1);
+		}
+	}
+}
+
+static void render_me(struct render_buf* out, const struct fs_render_ctx* ctx,
+                      const struct fs_field* field)
+{
+	if (strcmp(field->name, "nick") == 0)
+		put_line(out, ctx->my_nick);
+	else if (strcmp(field->name, "cid") == 0)
+		put_line(out, ctx->my_cid);
+	else if (strcmp(field->name, "sid") == 0)
+		put_sid(out, ctx->my_sid);
+	else if (strcmp(field->name, "support") == 0)
+		put_line(out, ctx->my_support);
+}
+
+static void render_user(struct render_buf* out, const struct fs_render_ctx* ctx,
+                        const struct fs_field* field)
+{
+	if (field->flags & FS_FIELD_RAW_INF)
+	{
+		/* Verbatim, escapes and all: this is the line the hub sent, and it is
+		   here for the reader who wants the fields this mount does not model.
+		   An ADC message carries its own terminating newline. */
+		if (ctx->inf)
+			put_mem(out, ctx->inf->cache, ctx->inf->length);
+		return;
+	}
+
+	if (field->inf)
+	{
+		put_inf_field(out, ctx->inf, field);
+		return;
+	}
+
+	if (strcmp(field->name, "ip") == 0)
+		put_address(out, ctx->inf);
+	else if (strcmp(field->name, "sid") == 0)
+		put_sid(out, ctx->sid);
+	else if (strcmp(field->name, "connected") == 0)
+		put_timestamp(out, ctx->since);
+}
+
+ssize_t fs_render(const struct fs_node* node, const struct fs_render_ctx* ctx,
+                  char* buf, size_t size)
+{
+	struct render_buf out;
+
+	if (!node || !ctx || !node->field)
+		return -1;
+
+	out.len = 0;
+	out.overflow = 0;
+
+	switch (node->type)
+	{
+		case FS_NODE_HUB_FILE:
+			render_hub(&out, ctx, node->field);
+			break;
+
+		case FS_NODE_ME_FILE:
+			render_me(&out, ctx, node->field);
+			break;
+
+		case FS_NODE_USER_FILE:
+			render_user(&out, ctx, node->field);
+			break;
+
+		default:
+			return -1;
+	}
+
+	if (out.overflow)
+		return -1;
+
+	if (out.len <= size && buf)
+		memcpy(buf, out.data, out.len);
+
+	return (ssize_t) out.len;
+}

--- a/src/fuse/render.h
+++ b/src/fuse/render.h
@@ -1,0 +1,97 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAVE_UHUB_FUSE_RENDER_H
+#define HAVE_UHUB_FUSE_RENDER_H
+
+#include "system.h"
+#include "adc/adctypes.h"
+#include "fuse/nodes.h"
+
+struct adc_message;
+
+/**
+ * Turning hub state into the bytes of a file.
+ *
+ * A metadata file is rendered once, at open(), and the snapshot is what the
+ * reader sees for as long as the descriptor is open. That is deliberate: a
+ * user's INF can be replaced between two read() calls of the same file, and a
+ * reader that got the first half of one nick and the second half of another
+ * would have no way to tell. A new open() sees the new value.
+ *
+ * The rendering is one value per file, terminated by a newline, so the mount
+ * is usable from a shell without a parser. A field the user did not advertise
+ * renders as an empty file -- except for the numeric ones (FS_FIELD_NUMERIC),
+ * where "absent" and "zero" mean the same thing to every client that sends
+ * them, and an empty file would only be a worse spelling of 0.
+ */
+
+/**
+ * Everything the renderer may read.
+ *
+ * All strings may be NULL, which renders as absent. The caller fills in the
+ * part that matches the node being rendered and leaves the rest zeroed.
+ */
+struct fs_render_ctx
+{
+	/* hub/ */
+	const char* hub_state;       /** offline, connecting or online */
+	const char* hub_name;
+	const char* hub_description;
+	const char* hub_version;
+	const char* hub_address;
+	const char* hub_support;     /** the hub's ISUP list */
+	const char* tls_version;     /** NULL when the hub connection is plaintext */
+	const char* tls_cipher;
+	size_t      hub_users;
+
+	/* me/ */
+	const char* my_nick;
+	const char* my_cid;
+	const char* my_support;
+	sid_t       my_sid;
+
+	/* users/<cid>/ */
+	struct adc_message* inf;     /** the stored BINF; may be NULL */
+	sid_t               sid;
+	time_t              since;   /** when this user was first seen */
+};
+
+/**
+ * Render one metadata file.
+ *
+ * @param node  a resolved FS_NODE_{HUB,ME,USER}_FILE.
+ * @param ctx   the state to render from.
+ * @param buf   receives the contents; not NUL terminated, and untouched on
+ *              failure. May be NULL together with a @p size of 0 to measure.
+ * @param size  the space in @p buf.
+ * @return the number of bytes the file holds, which may exceed @p size (in
+ *         which case nothing was written), or -1 if @p node is not a file this
+ *         module renders.
+ */
+extern ssize_t fs_render(const struct fs_node* node, const struct fs_render_ctx* ctx,
+                         char* buf, size_t size);
+
+/**
+ * Format @p when as "2026-08-20T21:15:03Z", in UTC.
+ * @return the number of bytes written, excluding the NUL, or 0 if it did not fit.
+ */
+extern size_t fs_render_timestamp(time_t when, char* buf, size_t size);
+
+#endif /* HAVE_UHUB_FUSE_RENDER_H */

--- a/src/fuse/roster.c
+++ b/src/fuse/roster.c
@@ -1,0 +1,406 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fuse/roster.h"
+#include "fuse/nodes.h"
+#include "adc/adcconst.h"
+#include "adc/message.h"
+#include "adc/sid.h"
+#include "util/memory.h"
+#include "util/rbtree.h"
+
+static int cmp_cid(const void* a, const void* b)
+{
+	return strcmp((const char*) a, (const char*) b);
+}
+
+/* SIDs are 20 bits, so the difference cannot overflow an int. */
+static int cmp_sid(const void* a, const void* b)
+{
+	return (int) ((intptr_t) a - (intptr_t) b);
+}
+
+static const void* sid_key(sid_t sid)
+{
+	return (const void*) (intptr_t) sid;
+}
+
+struct fs_roster* fs_roster_create(void)
+{
+	struct fs_roster* roster = (struct fs_roster*) hub_malloc_zero(sizeof(struct fs_roster));
+	if (!roster)
+		return NULL;
+
+	roster->by_sid = rb_tree_create(cmp_sid, NULL, NULL);
+	roster->by_cid = rb_tree_create(cmp_cid, NULL, NULL);
+
+	if (!roster->by_sid || !roster->by_cid)
+	{
+		fs_roster_destroy(roster);
+		return NULL;
+	}
+
+	return roster;
+}
+
+static void user_free(struct fs_roster_user* user)
+{
+	if (!user)
+		return;
+
+	adc_msg_free(user->inf);
+	hub_free(user);
+}
+
+void fs_roster_clear(struct fs_roster* roster)
+{
+	struct rb_node* node;
+
+	if (!roster)
+		return;
+
+	/* The CID key is inside the user struct, so the user must come out of both
+	   trees before it is freed. */
+	while ((node = rb_tree_first(roster->by_sid)) != NULL)
+	{
+		struct fs_roster_user* user = (struct fs_roster_user*) node->value;
+
+		rb_tree_remove(roster->by_sid, node->key);
+		if (user)
+		{
+			rb_tree_remove(roster->by_cid, user->cid);
+			user_free(user);
+		}
+	}
+
+	/*
+	 * Reset the CID tree's iterator, which the loop above never touched: it
+	 * only ever removed from that tree. A walk left in progress by anybody --
+	 * a lookup that stopped at its match, a listing that returned early --
+	 * leaves a stack behind, and rb_tree_destroy() aborts on one. On an empty
+	 * tree this clears it and returns NULL, which is the only way to say
+	 * "abandon any walk" through that API.
+	 */
+	rb_tree_first(roster->by_cid);
+}
+
+void fs_roster_destroy(struct fs_roster* roster)
+{
+	if (!roster)
+		return;
+
+	if (roster->by_sid && roster->by_cid)
+		fs_roster_clear(roster);
+
+	if (roster->by_sid)
+		rb_tree_destroy(roster->by_sid);
+
+	if (roster->by_cid)
+		rb_tree_destroy(roster->by_cid);
+
+	hub_free(roster);
+}
+
+/**
+ * Merge @p update into @p user's stored INF.
+ *
+ * Field by field, so a partial update keeps everything it did not mention.
+ * On OOM the previous INF is kept and the update is dropped -- stale is better
+ * than half-applied.
+ */
+static int merge_inf(struct fs_roster_user* user, struct adc_message* update)
+{
+	struct adc_message* merged = adc_msg_copy(user->inf);
+	char* argument;
+	size_t n = 0;
+
+	if (!merged)
+		return 0;
+
+	argument = adc_msg_get_argument(update, n++);
+	while (argument)
+	{
+		if (strlen(argument) >= 2)
+		{
+			char prefix[2] = { argument[0], argument[1] };
+			adc_msg_replace_named_argument(merged, prefix, argument + 2);
+		}
+
+		hub_free(argument);
+		argument = adc_msg_get_argument(update, n++);
+	}
+
+	adc_msg_free(user->inf);
+	user->inf = merged;
+	return 1;
+}
+
+enum fs_roster_result fs_roster_update(struct fs_roster* roster, struct adc_message* binf, time_t now)
+{
+	struct fs_roster_user* user;
+	char* cid;
+
+	if (!roster || !binf || !binf->source)
+		return FS_ROSTER_REJECTED;
+
+	user = fs_roster_by_sid(roster, binf->source);
+	if (user)
+		return merge_inf(user, binf) ? FS_ROSTER_UPDATED : FS_ROSTER_REJECTED;
+
+	/* A first INF without an ID is either a hub that does not relay one or a
+	   user the mount cannot name. Either way there is no path to put them at. */
+	cid = adc_msg_get_named_argument(binf, ADC_INF_FLAG_CLIENT_ID);
+	if (!cid)
+		return FS_ROSTER_REJECTED;
+
+	if (!fs_is_base32_hash(cid))
+	{
+		hub_free(cid);
+		return FS_ROSTER_REJECTED;
+	}
+
+	user = (struct fs_roster_user*) hub_malloc_zero(sizeof(struct fs_roster_user));
+	if (!user)
+	{
+		hub_free(cid);
+		return FS_ROSTER_REJECTED;
+	}
+
+	user->sid = binf->source;
+	user->since = now;
+	memcpy(user->cid, cid, MAX_CID_LEN + 1);
+	hub_free(cid);
+
+	user->inf = adc_msg_copy(binf);
+	if (!user->inf)
+	{
+		user_free(user);
+		return FS_ROSTER_REJECTED;
+	}
+
+	/* Two SIDs claiming one CID is a hub that let a ghost linger. The newcomer
+	   is the one whose SID is live, so it wins the CID and the old entry goes. */
+	{
+		struct fs_roster_user* incumbent = fs_roster_by_cid(roster, user->cid);
+		if (incumbent)
+			fs_roster_remove(roster, incumbent->sid);
+	}
+
+	if (!rb_tree_insert(roster->by_sid, sid_key(user->sid), user))
+	{
+		user_free(user);
+		return FS_ROSTER_REJECTED;
+	}
+
+	if (!rb_tree_insert(roster->by_cid, user->cid, user))
+	{
+		rb_tree_remove(roster->by_sid, sid_key(user->sid));
+		user_free(user);
+		return FS_ROSTER_REJECTED;
+	}
+
+	return FS_ROSTER_ADDED;
+}
+
+int fs_roster_remove(struct fs_roster* roster, sid_t sid)
+{
+	struct fs_roster_user* user = fs_roster_by_sid(roster, sid);
+
+	if (!user)
+		return 0;
+
+	rb_tree_remove(roster->by_cid, user->cid);
+	rb_tree_remove(roster->by_sid, sid_key(sid));
+	user_free(user);
+	return 1;
+}
+
+struct fs_roster_user* fs_roster_by_sid(struct fs_roster* roster, sid_t sid)
+{
+	if (!roster || !sid)
+		return NULL;
+
+	return (struct fs_roster_user*) rb_tree_get(roster->by_sid, sid_key(sid));
+}
+
+struct fs_roster_user* fs_roster_by_cid(struct fs_roster* roster, const char* cid)
+{
+	if (!roster || !cid)
+		return NULL;
+
+	return (struct fs_roster_user*) rb_tree_get(roster->by_cid, cid);
+}
+
+size_t fs_roster_size(struct fs_roster* roster)
+{
+	return roster ? rb_tree_size(roster->by_cid) : 0;
+}
+
+struct fs_roster_user* fs_roster_first(struct fs_roster* roster)
+{
+	struct rb_node* node;
+
+	if (!roster)
+		return NULL;
+
+	node = rb_tree_first(roster->by_cid);
+	return node ? (struct fs_roster_user*) node->value : NULL;
+}
+
+struct fs_roster_user* fs_roster_next(struct fs_roster* roster)
+{
+	struct rb_node* node;
+
+	if (!roster)
+		return NULL;
+
+	node = rb_tree_next(roster->by_cid);
+	return node ? (struct fs_roster_user*) node->value : NULL;
+}
+
+size_t fs_roster_nick(const struct fs_roster_user* user, char* buf, size_t size)
+{
+	char* escaped;
+	char* nick;
+	size_t len;
+
+	if (!buf || !size)
+		return 0;
+
+	buf[0] = '\0';
+
+	if (!user || !user->inf)
+		return 0;
+
+	escaped = adc_msg_get_named_argument(user->inf, ADC_INF_FLAG_NICK);
+	if (!escaped)
+		return 0;
+
+	nick = adc_msg_unescape(escaped);
+	hub_free(escaped);
+
+	if (!nick)
+		return 0;
+
+	len = strlen(nick);
+	if (len >= size)
+		len = size - 1;
+
+	memcpy(buf, nick, len);
+	buf[len] = '\0';
+	hub_free(nick);
+
+	return len;
+}
+
+struct name_entry
+{
+	char name[FS_DISPLAY_NAME_MAX];
+};
+
+/**
+ * Finish a walk that stopped early.
+ *
+ * The tree keeps its iteration state inside itself, on a stack it pushes to on
+ * the way down. A walk abandoned part-way leaves that stack loaded, and
+ * rb_tree_destroy() asserts that it is empty -- so a lookup that stops at the
+ * first match takes the mount down at unmount time, long after the walk, and
+ * only when no later walk happened to run to the end and reset it.
+ */
+static void roster_finish_walk(struct fs_roster* roster)
+{
+	while (rb_tree_next(roster->by_cid))
+		; /* nothing: the walking is the point */
+}
+
+int fs_roster_walk_names(struct fs_roster* roster, fs_name_cb cb, void* ptr)
+{
+	struct fs_roster_user* user;
+	struct name_entry* seen;
+	size_t count;
+	size_t used = 0;
+	int stopped = 0;
+
+	if (!roster || !cb)
+		return 0;
+
+	/* The names handed out so far, to spot a collision. A hub where this array
+	   is large is a hub where the walk itself is the expensive part; readdir is
+	   not a hot path, and losing the allocation only costs the "~<sid>" that
+	   would have told two identical names apart. */
+	count = fs_roster_size(roster);
+	seen = count ? (struct name_entry*) hub_malloc(count * sizeof(struct name_entry)) : NULL;
+
+	for (user = fs_roster_first(roster); user; user = fs_roster_next(roster))
+	{
+		char nick[MAX_NICK_LEN + 1];
+		char name[FS_DISPLAY_NAME_MAX];
+
+		fs_roster_nick(user, nick, sizeof(nick));
+		fs_sanitize_nick(nick, name, MAX_NICK_LEN + 1);
+
+		if (seen && used < count)
+		{
+			size_t n;
+
+			for (n = 0; n < used; n++)
+			{
+				if (strcmp(seen[n].name, name) == 0)
+				{
+					size_t len = strlen(name);
+					snprintf(&name[len], sizeof(name) - len, "~%s", sid_to_string(user->sid));
+					break;
+				}
+			}
+
+			memcpy(seen[used].name, name, sizeof(name));
+			used++;
+		}
+
+		if (cb(ptr, name, user))
+		{
+			stopped = 1;
+			roster_finish_walk(roster);
+			break;
+		}
+	}
+
+	hub_free(seen);
+	return stopped;
+}
+
+struct fs_roster_user* fs_roster_by_nick(struct fs_roster* roster, const char* nick)
+{
+	struct fs_roster_user* user;
+	char current[MAX_NICK_LEN + 1];
+
+	if (!roster || !nick)
+		return NULL;
+
+	for (user = fs_roster_first(roster); user; user = fs_roster_next(roster))
+	{
+		if (fs_roster_nick(user, current, sizeof(current)) && strcmp(current, nick) == 0)
+		{
+			roster_finish_walk(roster);
+			return user;
+		}
+	}
+
+	return NULL;
+}

--- a/src/fuse/roster.h
+++ b/src/fuse/roster.h
@@ -1,0 +1,150 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAVE_UHUB_FUSE_ROSTER_H
+#define HAVE_UHUB_FUSE_ROSTER_H
+
+#include "system.h"
+#include "adc/adctypes.h"
+
+struct adc_message;
+struct rb_tree;
+
+/**
+ * Who is on the hub, as the mount sees them.
+ *
+ * The roster keeps each user's INF and nothing else. It does not decompose it
+ * into typed fields, for the same reason the hub does not (see struct hub_user
+ * in src/core/user.h): a client may advertise anything the grammar allows, the
+ * set grows with every extension, and a mount that modelled the fields it knew
+ * about would quietly drop the ones it did not. Rendering reads the arguments
+ * it wants at open() time, and users/<cid>/inf hands over the line itself.
+ *
+ * An INF update carries only the fields that changed, so an update is merged
+ * into the stored line rather than replacing it -- the same merge the hub does
+ * in user_update_info() (src/core/user.c:140).
+ *
+ * Keyed by SID, which is what the hub puts on the wire, and by CID, which is
+ * what the mount puts in a path. A user with no CID is not admitted: the mount
+ * has no name for one.
+ *
+ * This lives on the ADC thread and is not locked. Nothing else may touch it.
+ */
+
+struct fs_roster_user
+{
+	sid_t sid;
+	char cid[MAX_CID_LEN + 1];
+
+	/** The merged INF. Never NULL for a user in the roster. */
+	struct adc_message* inf;
+
+	/** When this user was first seen, for users/<cid>/connected. */
+	time_t since;
+};
+
+struct fs_roster
+{
+	struct rb_tree* by_sid;
+	struct rb_tree* by_cid;
+};
+
+/** @return a new empty roster, or NULL on OOM. */
+extern struct fs_roster* fs_roster_create(void);
+
+/** Empty the roster. Used when the hub connection drops. */
+extern void fs_roster_clear(struct fs_roster* roster);
+
+extern void fs_roster_destroy(struct fs_roster* roster);
+
+enum fs_roster_result
+{
+	FS_ROSTER_REJECTED = 0,  /** No SID, no CID on a first INF, or OOM. */
+	FS_ROSTER_ADDED    = 1,
+	FS_ROSTER_UPDATED  = 2,
+};
+
+/**
+ * Add @p binf, or merge it into what is already stored for its SID.
+ *
+ * @p binf is not retained: the roster keeps a copy.
+ * @param now the time to stamp a newly added user with.
+ */
+extern enum fs_roster_result fs_roster_update(struct fs_roster* roster,
+                                              struct adc_message* binf, time_t now);
+
+/** @return 1 if a user was removed. */
+extern int fs_roster_remove(struct fs_roster* roster, sid_t sid);
+
+extern struct fs_roster_user* fs_roster_by_sid(struct fs_roster* roster, sid_t sid);
+extern struct fs_roster_user* fs_roster_by_cid(struct fs_roster* roster, const char* cid);
+
+extern size_t fs_roster_size(struct fs_roster* roster);
+
+/**
+ * Iterate, in CID order -- which is the order users/ lists them in.
+ *
+ * The iterator lives in the tree, so exactly one walk may be in progress at a
+ * time, and nothing may be added or removed during it.
+ */
+extern struct fs_roster_user* fs_roster_first(struct fs_roster* roster);
+extern struct fs_roster_user* fs_roster_next(struct fs_roster* roster);
+
+/**
+ * Find the user advertising @p nick, for by-nick/.
+ *
+ * Nicks are unique on a hub, but only at any one moment: this is a linear walk
+ * and it compares the unescaped NI, so a nick containing a space matches the
+ * name a shell would type. @return NULL if nobody is using it.
+ */
+extern struct fs_roster_user* fs_roster_by_nick(struct fs_roster* roster, const char* nick);
+
+/** Room for a by-nick name: a nick, and the "~SID" a collision adds. */
+#define FS_DISPLAY_NAME_MAX (MAX_NICK_LEN + 8)
+
+/**
+ * Called once per user by fs_roster_walk_names().
+ * @return non-zero to stop the walk.
+ */
+typedef int (*fs_name_cb)(void* ptr, const char* name, struct fs_roster_user* user);
+
+/**
+ * Walk the roster, handing each user the name it goes by in by-nick/.
+ *
+ * The name is the user's nick with the bytes a filename cannot hold replaced
+ * (see fs_sanitize_nick). Nicks are unique on a hub but their sanitised forms
+ * need not be -- "a/b" and "a_b" collapse onto one name -- so a name already
+ * taken by an earlier user gets "~<sid>" appended, which is unique by
+ * construction.
+ *
+ * Listing the directory and resolving one name in it are the same walk, so
+ * both go through here: a lookup that generated names by a different rule
+ * would answer for names the listing never showed.
+ *
+ * @return 1 if @p cb stopped the walk.
+ */
+extern int fs_roster_walk_names(struct fs_roster* roster, fs_name_cb cb, void* ptr);
+
+/**
+ * The unescaped NI of @p user, copied into @p buf.
+ * @return the number of bytes written, excluding the NUL, or 0.
+ */
+extern size_t fs_roster_nick(const struct fs_roster_user* user, char* buf, size_t size);
+
+#endif /* HAVE_UHUB_FUSE_ROSTER_H */

--- a/src/fuse/session.c
+++ b/src/fuse/session.c
@@ -1,0 +1,824 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fuse/session.h"
+#include "fuse/bridge.h"
+#include "fuse/config.h"
+#include "fuse/chatlog.h"
+#include "fuse/render.h"
+#include "fuse/roster.h"
+#include "fuse/transfer.h"
+#include "seeder/hubconn.h"
+#include "adc/adcconst.h"
+#include "adc/message.h"
+#include "network/backend.h"
+#include "network/network.h"
+#include "network/timeout.h"
+#include "tools/adcclient.h"
+#include "util/log.h"
+#include "util/memory.h"
+
+#define FS_CLIENT_DESCRIPTION "filesystem"
+
+static void session_schedule_reconnect(struct fs_session* session);
+static void session_schedule_tick(struct fs_session* session);
+
+/** Replace a stored string with a copy of @p value (which may be NULL). */
+static void set_string(char** target, const char* value)
+{
+	hub_free(*target);
+	*target = value ? hub_strdup(value) : NULL;
+}
+
+/**
+ * Take in one BINF.
+ *
+ * The client library reports a join, but never an update -- it keeps no roster
+ * of its own to diff against (see ADC_CLIENT_USER_UPDATE in adcclient.h). The
+ * raw line is the only place both are visible, so the roster is driven from
+ * there and the join event is left alone. It also means the mount stores the
+ * line as it arrived, which is what users/<cid>/inf hands back.
+ */
+static void session_on_inf(struct fs_session* session, const char* line)
+{
+	struct adc_message* msg = adc_msg_parse(line, strlen(line));
+
+	if (!msg)
+		return;  /* Not ours to complain about: the client library logs it. */
+
+	fs_roster_update(session->roster, msg, time(NULL));
+	adc_msg_free(msg);
+}
+
+/** The name to write a SID down as: a nick if we know one, the SID if not. */
+static void session_name_of(struct fs_session* session, sid_t sid, char* buf, size_t size)
+{
+	struct fs_roster_user* user;
+
+	/* SID zero is the hub speaking for itself -- a status line, the reply to a
+	   !command -- and it is not in the roster, since it never sends an INF
+	   with a CID. Writing it down as "AAAA" would be accurate and useless. */
+	if (!sid)
+	{
+		snprintf(buf, size, "%s", session->hub_name ? session->hub_name : "hub");
+		return;
+	}
+
+	user = fs_roster_by_sid(session->roster, sid);
+
+	if (user && fs_roster_nick(user, buf, size))
+		return;
+
+	snprintf(buf, size, "%s", sid_to_string(sid));
+}
+
+/**
+ * Write one message down.
+ *
+ * The format is a timestamp, a name and the text, one message per line, so
+ * that grep and read(1) work on it without anything having to parse ADC. An
+ * action ("/me waves") is marked with a star instead of angle brackets, the
+ * convention every DC client already displays.
+ */
+static void session_log_message(struct fs_chatlog* log, time_t when, const char* prefix,
+                                const char* name, const char* text, int action)
+{
+	char line[FS_CHAT_MAX + MAX_NICK_LEN + 64];
+	char stamp[32];
+
+	if (!fs_render_timestamp(when, stamp, sizeof(stamp)))
+		stamp[0] = '\0';
+
+	if (action)
+		snprintf(line, sizeof(line), "%s %s* %s %s", stamp, prefix, name, text);
+	else
+		snprintf(line, sizeof(line), "%s %s<%s> %s", stamp, prefix, name, text);
+
+	fs_chatlog_append_line(log, line);
+}
+
+/**
+ * Note something that happened to the connection itself in the log.
+ *
+ * Somebody tailing chat/main should be able to tell a quiet hub from one that
+ * is not there any more, and a gap in the conversation from a gap in the
+ * connection.
+ */
+static void session_log_event(struct fs_session* session, const char* fmt, ...)
+{
+	char text[256];
+	char line[320];
+	char stamp[32];
+	va_list args;
+
+	va_start(args, fmt);
+	vsnprintf(text, sizeof(text), fmt, args);
+	va_end(args);
+
+	if (!fs_render_timestamp(time(NULL), stamp, sizeof(stamp)))
+		stamp[0] = '\0';
+
+	snprintf(line, sizeof(line), "%s -- %s", stamp, text);
+	fs_chatlog_append_line(session->chat_main, line);
+}
+
+static void session_on_message(struct fs_session* session, struct ADC_chat_message* chat)
+{
+	char name[MAX_NICK_LEN + 1];
+	int private_msg = (chat->flags & chat_flags_private) != 0;
+	int action = (chat->flags & chat_flags_action) != 0;
+
+	if (!chat->message)
+		return;
+
+	session_name_of(session, chat->from_sid, name, sizeof(name));
+
+	session_log_message(private_msg ? session->chat_private : session->chat_main,
+	                    time(NULL), "", name, chat->message, action);
+}
+
+static void session_on_disconnected(struct fs_session* session)
+{
+	if (session->state == FS_SESSION_ONLINE)
+		session_log_event(session, "disconnected from %s", session->address);
+
+	/* An empty users/ is the truth once the connection is gone. Keeping the
+	   last known list would leave a directory that looks live and is not. */
+	fs_roster_clear(session->roster);
+
+	/* Nobody is going to answer a download that was waiting on this hub. */
+	if (session->transfer)
+		fs_transfer_abort_all(session->transfer, -ENOTCONN);
+
+	set_string(&session->tls_version, NULL);
+	set_string(&session->tls_cipher, NULL);
+
+	/* What the hub said about itself goes with it, for the same reason: an
+	   offline mount should not read like an online one. hub/address survives
+	   -- it is what was configured, not what the hub claimed -- and hub/state
+	   is there to be looked at. */
+	set_string(&session->hub_name, NULL);
+	set_string(&session->hub_description, NULL);
+	set_string(&session->hub_version, NULL);
+
+	if (session->state == FS_SESSION_FATAL)
+		return;
+
+	session->state = FS_SESSION_OFFLINE;
+
+	if (session->running)
+		session_schedule_reconnect(session);
+}
+
+static int session_callback(struct ADC_client* client, enum ADC_client_callback_type type,
+                            struct ADC_client_callback_data* data)
+{
+	struct fs_session* session = (struct fs_session*) ADC_client_get_ptr(client);
+
+	if (!session)
+		return 0;
+
+	switch (type)
+	{
+		case ADC_CLIENT_CONNECTING:
+			session->state = FS_SESSION_CONNECTING;
+			break;
+
+		case ADC_CLIENT_LOGGED_IN:
+			session->state = FS_SESSION_ONLINE;
+			session->backoff = 0;
+			LOG_INFO("Logged in to %s as %s", session->address, session->nick);
+			session_log_event(session, "connected to %s", session->address);
+			session_schedule_tick(session);
+			break;
+
+		case ADC_CLIENT_DISCONNECTED:
+			session_on_disconnected(session);
+			break;
+
+		case ADC_CLIENT_SSL_OK:
+			if (data && data->tls_info)
+			{
+				set_string(&session->tls_version, data->tls_info->version);
+				set_string(&session->tls_cipher, data->tls_info->cipher);
+			}
+			break;
+
+		case ADC_CLIENT_SSL_KEYPRINT_ERROR:
+			/* The hub did not present the certificate it was pinned to. That
+			   is a configuration error or an interception, never a transient
+			   fault, so retrying it would only repeat it. */
+			LOG_ERROR("%s did not present the pinned certificate; not retrying", session->address);
+			session->state = FS_SESSION_FATAL;
+			break;
+
+		case ADC_CLIENT_HUB_INFO:
+			if (data && data->hubinfo)
+			{
+				set_string(&session->hub_name, data->hubinfo->name);
+				set_string(&session->hub_description, data->hubinfo->description);
+				set_string(&session->hub_version, data->hubinfo->version);
+			}
+			break;
+
+		case ADC_CLIENT_MESSAGE:
+			if (data && data->chat)
+				session_on_message(session, data->chat);
+			break;
+
+		/* A search result, and the request that follows from it, are the
+		   transfer layer's business; the session only knows who is who. */
+		case ADC_CLIENT_SEARCH_REP:
+			if (data && data->message && session->transfer)
+			{
+				char* tth = adc_msg_get_named_argument(data->message, ADC_SCH_FLAG_TTH);
+				char* size = adc_msg_get_named_argument(data->message, ADC_RES_FLAG_FILE_SIZE);
+
+				if (tth)
+					fs_transfer_on_search_result(session->transfer, data->message->source, tth,
+						size ? strtoull(size, NULL, 10) : 0);
+
+				hub_free(tth);
+				hub_free(size);
+			}
+			break;
+
+		case ADC_CLIENT_CONNECT_REQ:
+			if (data && data->message && session->transfer)
+			{
+				char* protocol = adc_msg_get_argument(data->message, 0);
+				char* port = adc_msg_get_argument(data->message, 1);
+				char* token = adc_msg_get_argument(data->message, 2);
+
+				if (protocol && port && token)
+					fs_transfer_on_connect_req(session->transfer, data->message->source,
+						protocol, (uint16_t) strtoul(port, NULL, 10), token);
+
+				hub_free(protocol);
+				hub_free(port);
+				hub_free(token);
+			}
+			break;
+
+		case ADC_CLIENT_USER_QUIT:
+			if (data && data->quit)
+				fs_roster_remove(session->roster, data->quit->sid);
+			break;
+
+		case ADC_CLIENT_RAW_LINE:
+			if (data && data->line && strncmp(data->line, "BINF ", 5) == 0)
+				session_on_inf(session, data->line);
+			break;
+
+		default:
+			break;
+	}
+
+	return 0;
+}
+
+/**
+ * Build a chat message and send it.
+ *
+ * @param to 0 for the main chat (BMSG), or a SID for a private one (DMSG).
+ */
+static int session_send_message(struct fs_session* session, sid_t to, const char* text)
+{
+	struct adc_message* msg;
+	char* escaped;
+	sid_t own = ADC_client_get_sid(session->client);
+	int ok;
+
+	if (session->state != FS_SESSION_ONLINE || !own)
+		return -ENOTCONN;
+
+	if (!text || !*text)
+		return 0;   /* Nothing to say is not an error; it is just nothing. */
+
+	if (strlen(text) > FS_CHAT_MAX)
+		return -EMSGSIZE;
+
+	escaped = adc_msg_escape(text);
+	if (!escaped)
+		return -ENOMEM;
+
+	if (to)
+		msg = adc_msg_construct_source_dest(ADC_CMD_DMSG, own, to, strlen(escaped) + 32);
+	else
+		msg = adc_msg_construct_source(ADC_CMD_BMSG, own, strlen(escaped) + 32);
+
+	if (!msg)
+	{
+		hub_free(escaped);
+		return -ENOMEM;
+	}
+
+	/* adc_msg_add_argument() returns 0 for success, not 1. */
+	ok = (adc_msg_add_argument(msg, escaped) == 0);
+	hub_free(escaped);
+
+	/* PM names the conversation. For one-to-one that is our own SID, the same
+	   convention the hub uses for its own command replies. */
+	if (ok && to)
+	{
+		char pm_flag[8];
+		snprintf(pm_flag, sizeof(pm_flag), "%s%s", ADC_MSG_FLAG_PRIVATE, sid_to_string(own));
+		ok = (adc_msg_add_argument(msg, pm_flag) == 0);
+	}
+
+	if (!ok)
+	{
+		adc_msg_free(msg);
+		return -ENOMEM;
+	}
+
+	ADC_client_send(session->client, msg);
+	adc_msg_free(msg);
+	return 0;
+}
+
+int fs_session_send_chat(struct fs_session* session, const char* text)
+{
+	/* No local echo: the hub broadcasts a B message back to its sender, so
+	   what we said arrives in chat/main by the same route as everybody else's,
+	   and writing it down here as well would double it. */
+	return session_send_message(session, 0, text);
+}
+
+int fs_session_send_pm(struct fs_session* session, const char* cid, const char* text)
+{
+	struct fs_roster_user* user = fs_roster_by_cid(session->roster, cid);
+	char name[MAX_NICK_LEN + 1];
+	int result;
+
+	if (!user)
+		return -ENOENT;
+
+	result = session_send_message(session, user->sid, text);
+	if (result != 0 || !text || !*text)
+		return result;
+
+	/* A D message is delivered to its target and not to its sender, so unlike
+	   the main chat this one has to be written down here -- otherwise
+	   chat/private would hold half of every conversation. */
+	fs_roster_nick(user, name, sizeof(name));
+	session_log_message(session->chat_private, time(NULL), "-> ", name, text, 0);
+	return 0;
+}
+
+int fs_session_peer_by_sid(struct fs_session* session, sid_t sid, struct fs_peer* out)
+{
+	struct fs_roster_user* user = fs_roster_by_sid(session->roster, sid);
+	char* value;
+
+	if (!user || !out)
+		return 0;
+
+	memset(out, 0, sizeof(*out));
+	out->sid = sid;
+	memcpy(out->cid, user->cid, sizeof(out->cid));
+
+	value = adc_msg_get_named_argument(user->inf, ADC_INF_FLAG_SUPPORT);
+	if (value)
+	{
+		snprintf(out->support, sizeof(out->support), "%s", value);
+		hub_free(value);
+	}
+
+	/* I4 first, then I6: either is the hub's own observation of where this
+	   user is, and a peer reachable over both is reachable over v4. */
+	value = adc_msg_get_named_argument(user->inf, ADC_INF_FLAG_IPV4_ADDR);
+	if (!value)
+		value = adc_msg_get_named_argument(user->inf, ADC_INF_FLAG_IPV6_ADDR);
+
+	if (!value)
+		return 0;
+
+	if (!ip_convert_to_binary(value, &out->addr))
+	{
+		hub_free(value);
+		return 0;
+	}
+
+	hub_free(value);
+	return 1;
+}
+
+int fs_session_send_search_tth(struct fs_session* session, const char* tth, const char* token)
+{
+	struct adc_message* msg;
+	sid_t own = ADC_client_get_sid(session->client);
+
+	if (session->state != FS_SESSION_ONLINE || !own || !tth)
+		return 0;
+
+	/* Broadcast, because the point of searching is not knowing who has it. An
+	   exact TTH search is the cheapest question ADC has: a client either holds
+	   that hash or does not. */
+	msg = adc_msg_construct_source(ADC_CMD_BSCH, own, 64 + MAX_CID_LEN);
+	if (!msg)
+		return 0;
+
+	if (adc_msg_add_named_argument(msg, ADC_SCH_FLAG_TTH, tth) == -1 ||
+	    (token && *token &&
+	     adc_msg_add_named_argument_string(msg, ADC_SCH_FLAG_TOKEN, token) == -1))
+	{
+		adc_msg_free(msg);
+		return 0;
+	}
+
+	ADC_client_send(session->client, msg);
+	adc_msg_free(msg);
+	return 1;
+}
+
+int fs_session_send_ctm(struct fs_session* session, sid_t to, const char* protocol,
+                        uint16_t port, const char* token)
+{
+	struct adc_message* msg;
+	char port_str[8];
+	sid_t own = ADC_client_get_sid(session->client);
+	int ok;
+
+	if (session->state != FS_SESSION_ONLINE || !own || !to || !protocol || !*protocol ||
+	    !token || !*token || !port)
+		return 0;
+
+	msg = adc_msg_construct_source_dest(ADC_CMD_DCTM, own, to, 64 + SEED_TOKEN_MAX);
+	if (!msg)
+		return 0;
+
+	snprintf(port_str, sizeof(port_str), "%u", (unsigned) port);
+
+	ok = (adc_msg_add_argument(msg, protocol) == 0)
+	  && (adc_msg_add_argument(msg, port_str) == 0)
+	  && (adc_msg_add_argument(msg, token) == 0);
+
+	if (ok)
+		ADC_client_send(session->client, msg);
+
+	adc_msg_free(msg);
+	return ok;
+}
+
+const char* fs_session_own_cid(struct fs_session* session)
+{
+	return ADC_client_get_cid(session->client);
+}
+
+const char* fs_session_state_name(const struct fs_session* session)
+{
+	switch (session->state)
+	{
+		case FS_SESSION_CONNECTING: return "connecting";
+		case FS_SESSION_ONLINE:     return "online";
+		case FS_SESSION_FATAL:      return "failed";
+		default:                    return "offline";
+	}
+}
+
+/** Keep the once-a-second tick going while there is a hub to talk to. */
+static void session_schedule_tick(struct fs_session* session)
+{
+	struct timeout_queue* queue = net_backend_get_timeout_queue();
+
+	if (!queue || !session->timer || !session->transfer)
+		return;
+
+	if (!timeout_evt_is_scheduled(session->timer))
+		timeout_queue_insert(queue, session->timer, 1);
+}
+
+/* ------------------------------------------------------------- reconnecting */
+
+static void session_connect(struct fs_session* session)
+{
+	session->state = FS_SESSION_CONNECTING;
+
+	if (!ADC_client_connect(session->client, session->address))
+	{
+		/* A refused URL (a keyprint this build cannot check, say) is not worth
+		   retrying either, but a name that does not resolve yet is. */
+		LOG_WARN("Unable to connect to %s", session->address);
+		session->state = FS_SESSION_OFFLINE;
+		session_schedule_reconnect(session);
+	}
+}
+
+/**
+ * One timer for the whole session: the reconnect when offline, and the
+ * transfer layer's deadlines and retries the rest of the time. It reschedules
+ * itself for a second hence whenever anything is in flight, and stays quiet
+ * when there is nothing to do.
+ */
+static void session_timer_cb(struct timeout_evt* evt)
+{
+	struct fs_session* session = (struct fs_session*) evt->ptr;
+
+	if (!session->running)
+		return;
+
+	if (session->state == FS_SESSION_OFFLINE)
+	{
+		session_connect(session);
+		return;
+	}
+
+	if (session->transfer)
+	{
+		struct timeout_queue* queue = net_backend_get_timeout_queue();
+
+		fs_transfer_tick(session->transfer);
+
+		if (queue && !timeout_evt_is_scheduled(session->timer))
+			timeout_queue_insert(queue, session->timer, 1);
+	}
+}
+
+static void session_schedule_reconnect(struct fs_session* session)
+{
+	struct timeout_queue* queue = net_backend_get_timeout_queue();
+
+	if (!queue || !session->timer)
+		return;
+
+	/* Doubling, so a hub that is down does not get one connect per second for
+	   as long as the mount is up. */
+	if (!session->backoff)
+		session->backoff = FS_RECONNECT_MIN;
+	else if (session->backoff < FS_RECONNECT_MAX)
+		session->backoff *= 2;
+
+	if (session->backoff > FS_RECONNECT_MAX)
+		session->backoff = FS_RECONNECT_MAX;
+
+	LOG_DEBUG("Reconnecting to %s in %d seconds", session->address, (int) session->backoff);
+
+	if (timeout_evt_is_scheduled(session->timer))
+		timeout_queue_reschedule(queue, session->timer, session->backoff);
+	else
+		timeout_queue_insert(queue, session->timer, session->backoff);
+}
+
+/* ------------------------------------------------------------------ session */
+
+/**
+ * Give this mount an identity that survives a reconnect.
+ *
+ * Without a fixed PID the client library invents a new one every time it builds
+ * an INF, so the CID would change on every reconnect -- and a peer checks the
+ * CID in a client connection's CINF against the one the hub advertised. A
+ * transfer started after a reconnect would fail that check for no visible
+ * reason. Persisting it also means the hub sees the same client across
+ * restarts, which is what makes a registered account or a ban work at all.
+ *
+ * The PID is generated by the client library rather than here: building an INF
+ * and taking the PD out of it uses the one generator instead of adding a
+ * second.
+ */
+static void session_fix_identity(struct fs_session* session, const char* dir)
+{
+	char path[512];
+	char pid[MAX_CID_LEN + 8];
+	FILE* file;
+	size_t len = 0;
+
+	if (!dir || !*dir)
+		return;
+
+	snprintf(path, sizeof(path), "%s/identity", dir);
+	memset(pid, 0, sizeof(pid));
+
+	file = fopen(path, "r");
+	if (file)
+	{
+		len = fread(pid, 1, MAX_CID_LEN, file);
+		fclose(file);
+
+		while (len > 0 && (pid[len - 1] == '\n' || pid[len - 1] == '\r' || pid[len - 1] == ' '))
+			pid[--len] = '\0';
+	}
+
+	if (len != MAX_CID_LEN)
+	{
+		struct adc_message* info = ADC_client_build_info(session->client);
+		char* value = info ? adc_msg_get_named_argument(info, ADC_INF_FLAG_PRIVATE_ID) : NULL;
+		int fd;
+
+		if (!value || strlen(value) != MAX_CID_LEN)
+		{
+			hub_free(value);
+			adc_msg_free(info);
+			return;
+		}
+
+		memcpy(pid, value, MAX_CID_LEN + 1);
+		hub_free(value);
+		adc_msg_free(info);
+
+		/* 0600 from the moment it exists: the PID *is* the identity, and a
+		   window in which it is world readable is a window in which it can be
+		   taken. */
+		fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+		if (fd != -1)
+		{
+			FILE* out = fdopen(fd, "w");
+			if (out)
+			{
+				fprintf(out, "%s\n", pid);
+				fclose(out);
+			}
+			else
+			{
+				close(fd);
+			}
+		}
+	}
+
+	ADC_client_set_pid(session->client, pid);
+}
+
+struct fs_session* fs_session_create(const struct fs_config* config)
+{
+	struct fs_session* session;
+	const char* password;
+
+	if (!config || !config->address || !*config->address || !config->nick)
+		return NULL;
+
+	session = (struct fs_session*) hub_malloc_zero(sizeof(struct fs_session));
+	if (!session)
+		return NULL;
+
+	password = (config->password && *config->password) ? config->password : NULL;
+
+	session->address = hub_strdup(config->address);
+	session->nick = hub_strdup(config->nick);
+	session->password = password ? hub_strdup(password) : NULL;
+	session->roster = fs_roster_create();
+	session->chat_main = fs_chatlog_create(0);
+	session->chat_private = fs_chatlog_create(0);
+	session->timer = (struct timeout_evt*) hub_malloc_zero(sizeof(struct timeout_evt));
+	session->mounted = time(NULL);
+
+	if (!session->address || !session->nick || !session->roster || !session->timer ||
+	    !session->chat_main || !session->chat_private ||
+	    (password && !session->password))
+	{
+		fs_session_destroy(session);
+		return NULL;
+	}
+
+	timeout_evt_initialize(session->timer, session_timer_cb, session);
+
+	session->bridge = fs_bridge_create(session);
+	if (!session->bridge)
+	{
+		fs_session_destroy(session);
+		return NULL;
+	}
+
+	session->client = ADC_client_create(session->nick, FS_CLIENT_DESCRIPTION, session);
+	if (!session->client)
+	{
+		fs_session_destroy(session);
+		return NULL;
+	}
+
+	ADC_client_set_callback(session->client, session_callback);
+
+	if (session->password)
+		ADC_client_set_password(session->client, session->password);
+
+	/* The identity file lives beside the cache, which is the one directory a
+	   mount is given. Without one the CID is regenerated per login, which
+	   costs transfers rather than the mount itself, so it is not fatal. */
+	if (config->cache_dir && *config->cache_dir)
+		session_fix_identity(session, config->cache_dir);
+	else
+	{
+		char dir[512];
+		if (fs_config_default_cache_dir(dir, sizeof(dir)))
+			session_fix_identity(session, dir);
+	}
+
+	return session;
+}
+
+void fs_session_set_transfer(struct fs_session* session, struct fs_transfer* transfer)
+{
+	session->transfer = transfer;
+
+	/* This is how the rest of the hub learns the mount is worth dialling.
+	   Without TCP4 it is taken for a passive client and never connected to,
+	   which would leave it unable to fetch from the passive peers that make up
+	   most of a hub. */
+	if (transfer)
+		ADC_client_set_support(session->client, fs_transfer_support(transfer));
+}
+
+void fs_session_destroy(struct fs_session* session)
+{
+	if (!session)
+		return;
+
+	if (session->timer && timeout_evt_is_scheduled(session->timer))
+	{
+		struct timeout_queue* queue = net_backend_get_timeout_queue();
+		if (queue)
+			timeout_queue_remove(queue, session->timer);
+	}
+
+	if (session->transfer)
+		fs_transfer_destroy(session->transfer);
+
+	if (session->client)
+		ADC_client_destroy(session->client);
+
+	if (session->bridge)
+		fs_bridge_destroy(session->bridge);
+
+	fs_roster_destroy(session->roster);
+	fs_chatlog_destroy(session->chat_main);
+	fs_chatlog_destroy(session->chat_private);
+
+	hub_free(session->timer);
+	hub_free(session->address);
+	hub_free(session->nick);
+	hub_free(session->password);
+	hub_free(session->hub_name);
+	hub_free(session->hub_description);
+	hub_free(session->hub_version);
+	hub_free(session->tls_version);
+	hub_free(session->tls_cipher);
+	hub_free(session);
+}
+
+int fs_session_start(struct fs_session* session)
+{
+	session->running = 1;
+	session_connect(session);
+	return 1;
+}
+
+void fs_session_run(struct fs_session* session)
+{
+	while (session->running && net_backend_process())
+		; /* Every wake-up is a socket, a timer or the bridge. */
+
+	/* Nothing will answer a filesystem request from here on, and a FUSE thread
+	   waiting for one would keep the mount busy for ever. Parked downloads
+	   first, since those waiters are not on the bridge's own queue. */
+	if (session->transfer)
+		fs_transfer_abort_all(session->transfer, -ENOTCONN);
+
+	fs_bridge_shutdown(session->bridge);
+}
+
+void fs_session_stop(struct fs_session* session)
+{
+	if (!session->running)
+		return;
+
+	/* Set the flag, then wake the loop so it looks at it: the ADC thread is
+	   otherwise blocked in a poll with nothing due, and would not notice until
+	   the next timer or packet. */
+	session->running = 0;
+	fs_bridge_wake(session->bridge);
+}
+
+void fs_session_render_ctx(struct fs_session* session, struct fs_render_ctx* ctx)
+{
+	memset(ctx, 0, sizeof(*ctx));
+
+	ctx->hub_state = fs_session_state_name(session);
+	ctx->hub_name = session->hub_name;
+	ctx->hub_description = session->hub_description;
+	ctx->hub_version = session->hub_version;
+	ctx->hub_address = session->address;
+	ctx->hub_support = ADC_client_hub_support_list(session->client);
+	ctx->hub_users = fs_roster_size(session->roster);
+	ctx->tls_version = session->tls_version;
+	ctx->tls_cipher = session->tls_cipher;
+
+	ctx->my_nick = session->nick;
+	ctx->my_cid = ADC_client_get_cid(session->client);
+	ctx->my_support = ADC_client_get_support(session->client);
+	ctx->my_sid = ADC_client_get_sid(session->client);
+}

--- a/src/fuse/session.c
+++ b/src/fuse/session.c
@@ -34,6 +34,10 @@
 #include "util/log.h"
 #include "util/memory.h"
 
+/* For the mode bits on the identity file. system.h brings in <fcntl.h> but not
+   this, and on FreeBSD nothing else does either. */
+#include <sys/stat.h>
+
 #define FS_CLIENT_DESCRIPTION "filesystem"
 
 static void session_schedule_reconnect(struct fs_session* session);

--- a/src/fuse/session.h
+++ b/src/fuse/session.h
@@ -1,0 +1,199 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAVE_UHUB_FUSE_SESSION_H
+#define HAVE_UHUB_FUSE_SESSION_H
+
+#include "system.h"
+#include "adc/adctypes.h"
+#include "fuse/render.h"
+
+#include "network/ipcalc.h"
+#include "tools/adcclient.h"
+
+struct fs_config;
+
+struct ADC_client;
+struct fs_bridge;
+struct fs_chatlog;
+struct fs_roster;
+struct fs_transfer;
+struct timeout_evt;
+
+/**
+ * The hub, as one mount sees it.
+ *
+ * Everything here belongs to the ADC thread. A FUSE thread reaches it only
+ * through fs_bridge_submit(), never directly, so nothing in here is locked.
+ *
+ * The session logs in as an ordinary client -- it is one -- and keeps what the
+ * hub tells it: the roster, the hub's own INF, and whether the connection is
+ * encrypted. When the connection drops the roster is emptied rather than kept
+ * as a last known state: users/ would otherwise list people who are not there,
+ * and a stale directory that looks live is worse than an empty one.
+ */
+
+#define FS_RECONNECT_MIN 1
+#define FS_RECONNECT_MAX 60
+
+enum fs_session_state
+{
+	FS_SESSION_OFFLINE = 0,
+	FS_SESSION_CONNECTING,
+	FS_SESSION_ONLINE,
+	FS_SESSION_FATAL,      /** A pinned keyprint did not match. Do not retry. */
+};
+
+struct fs_session
+{
+	struct ADC_client* client;
+	struct fs_bridge* bridge;
+	struct fs_roster* roster;
+
+	char* address;         /** The adc:// or adcs:// URL, as configured. */
+	char* nick;
+	char* password;        /** May be NULL. */
+
+	enum fs_session_state state;
+
+	/* What the hub said about itself, for hub/. */
+	char* hub_name;
+	char* hub_description;
+	char* hub_version;
+	char* tls_version;     /** NULL while the connection is plaintext. */
+	char* tls_cipher;
+
+	/* What has been said. main is the hub's chat; private is what was said to
+	   us and what we said to somebody, which would otherwise be a
+	   conversation with only one side of it written down. */
+	struct fs_chatlog* chat_main;
+	struct fs_chatlog* chat_private;
+
+	/* Downloads, the cache they land in, and the port peers dial to deliver
+	   them. NULL when the mount was built without a transfer port. */
+	struct fs_transfer* transfer;
+
+	struct timeout_evt* timer;
+	size_t backoff;
+
+	/** Set when the ADC thread should leave its loop. */
+	int running;
+
+	time_t mounted;        /** For the timestamps on synthetic directories. */
+};
+
+/**
+ * Build the session, without connecting anything.
+ *
+ * @p config is read and not retained; the strings it needs are copied.
+ * @return NULL on OOM or an unusable configuration.
+ */
+extern struct fs_session* fs_session_create(const struct fs_config* config);
+
+/**
+ * Give the session its transfer machinery, before fs_session_start().
+ *
+ * Separate from creation because the two need each other: the transfer layer
+ * asks the hub through the session, and the session cannot announce what it
+ * supports until the transfer layer has told it which port and protocols are
+ * real. The session takes ownership.
+ */
+extern void fs_session_set_transfer(struct fs_session* session, struct fs_transfer* transfer);
+
+extern void fs_session_destroy(struct fs_session* session);
+
+/** Start connecting. @return 1 on success. */
+extern int fs_session_start(struct fs_session* session);
+
+/**
+ * Run the event loop until fs_session_stop() is called. This is the ADC
+ * thread's whole life.
+ */
+extern void fs_session_run(struct fs_session* session);
+
+/**
+ * Ask the loop to stop. Safe to call from another thread -- it only sets a
+ * flag and wakes the loop through the bridge.
+ */
+extern void fs_session_stop(struct fs_session* session);
+
+/**
+ * The name hub/state goes by: "offline", "connecting", "online" or "failed".
+ * "failed" is terminal -- a pinned keyprint that did not match is not retried.
+ */
+extern const char* fs_session_state_name(const struct fs_session* session);
+
+/** Longest chat message the mount will send. */
+#define FS_CHAT_MAX 1024
+
+/**
+ * Say @p text in the hub's main chat.
+ * @return 0, or a negative errno (-ENOTCONN when not logged in).
+ */
+extern int fs_session_send_chat(struct fs_session* session, const char* text);
+
+/**
+ * Send @p text privately to the user with @p cid.
+ * @return 0, -ENOENT when nobody on the hub has that CID, or -ENOTCONN.
+ */
+extern int fs_session_send_pm(struct fs_session* session, const char* cid, const char* text);
+
+/**
+ * Enough of another user to dial them.
+ *
+ * The address is the one the *hub* reported, which the hub overwrote with the
+ * one it observed (check_network() in src/core/inf.c) -- never one taken out of
+ * a CTM, and never one the peer chose for itself.
+ */
+struct fs_peer
+{
+	sid_t sid;
+	char cid[MAX_CID_LEN + 1];
+	char support[ADC_SUPPORT_MAX];
+	struct ip_addr_encap addr;
+};
+
+/** @return 1 if that SID is on the hub and has an address we can dial. */
+extern int fs_session_peer_by_sid(struct fs_session* session, sid_t sid, struct fs_peer* out);
+
+/**
+ * Ask the hub who has @p tth, as a BSCH naming that hash and nothing else.
+ * @return 1 if it was sent.
+ */
+extern int fs_session_send_search_tth(struct fs_session* session, const char* tth, const char* token);
+
+/**
+ * Tell @p to to connect to us on @p port and quote @p token.
+ *
+ * The mount is the one listening, so this is how it asks for a file: the peer
+ * dials in, and the transfer is requested over that connection. It is also the
+ * only arrangement that works when the peer is passive.
+ *
+ * @return 1 if it was sent.
+ */
+extern int fs_session_send_ctm(struct fs_session* session, sid_t to, const char* protocol,
+                               uint16_t port, const char* token);
+
+/** Our own CID, as the hub knows us. Never NULL once logged in. */
+extern const char* fs_session_own_cid(struct fs_session* session);
+
+/** Fill in @p ctx with the parts of the session the renderer reads. */
+extern void fs_session_render_ctx(struct fs_session* session, struct fs_render_ctx* ctx);
+
+#endif /* HAVE_UHUB_FUSE_SESSION_H */

--- a/src/fuse/stream.c
+++ b/src/fuse/stream.c
@@ -1,0 +1,280 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fuse/stream.h"
+#include "fuse/bridge.h"
+#include "fuse/transfer.h"
+#include "util/log.h"
+#include "util/memory.h"
+
+/**
+ * One open large file.
+ *
+ * The window is a single contiguous run of bytes: [have_start, have_end). A
+ * read inside it is a memcpy; a read outside it throws it away and asks for a
+ * new one starting where the reader is. That is deliberately the simplest
+ * thing that works -- a filesystem read is almost always either the next
+ * sequential chunk or a seek to somewhere else entirely, and a cache of
+ * scattered fragments would cost more bookkeeping than it saves.
+ */
+struct fs_stream
+{
+	struct fs_transfer* transfer;
+	char tth[MAX_CID_LEN + 1];
+	char cid[MAX_CID_LEN + 1];
+	uint64_t size;
+
+	char* window;
+	uint64_t have_start;
+	uint64_t have_end;
+
+	/* The request in flight, if any. */
+	char token[SEED_TOKEN_MAX + 1];
+	uint64_t want_start;
+	uint64_t want_end;
+	uint64_t got;          /** Bytes of it that have arrived. */
+	time_t started;
+
+	struct fs_task* waiters;
+	int failed;
+};
+
+struct fs_stream* fs_stream_open(struct fs_transfer* transfer, const char* tth,
+                                 const char* cid, uint64_t size)
+{
+	struct fs_stream* stream;
+
+	if (!transfer || !tth || !cid || !size)
+		return NULL;
+
+	stream = (struct fs_stream*) hub_malloc_zero(sizeof(struct fs_stream));
+	if (!stream)
+		return NULL;
+
+	stream->window = (char*) hub_malloc(FS_STREAM_WINDOW);
+	if (!stream->window)
+	{
+		hub_free(stream);
+		return NULL;
+	}
+
+	stream->transfer = transfer;
+	stream->size = size;
+	snprintf(stream->tth, sizeof(stream->tth), "%s", tth);
+	snprintf(stream->cid, sizeof(stream->cid), "%s", cid);
+	return stream;
+}
+
+void fs_stream_close(struct fs_stream* stream)
+{
+	if (!stream)
+		return;
+
+	/* Anything still waiting is waiting on a descriptor that is being closed. */
+	fs_stream_abort(stream, -EBADF);
+
+	hub_free(stream->window);
+	hub_free(stream);
+}
+
+const char* fs_stream_token(struct fs_stream* stream)
+{
+	return stream ? stream->token : "";
+}
+
+static void stream_wake(struct fs_stream* stream, int result)
+{
+	struct fs_task* task = stream->waiters;
+
+	stream->waiters = NULL;
+
+	while (task)
+	{
+		struct fs_task* next = task->next;
+
+		task->next = NULL;
+		fs_transfer_complete_task(stream->transfer, task, result);
+		task = next;
+	}
+}
+
+void fs_stream_abandon(struct fs_stream* stream, struct fs_task* task)
+{
+	struct fs_task** link;
+
+	if (!stream)
+		return;
+
+	for (link = &stream->waiters; *link; link = &(*link)->next)
+	{
+		if (*link == task)
+		{
+			*link = task->next;
+			task->next = NULL;
+			return;
+		}
+	}
+}
+
+void fs_stream_abort(struct fs_stream* stream, int error)
+{
+	if (!stream)
+		return;
+
+	stream->token[0] = '\0';
+	stream->want_start = stream->want_end = 0;
+	stream->got = 0;
+	stream_wake(stream, error);
+}
+
+int fs_stream_expired(struct fs_stream* stream, time_t now, int timeout)
+{
+	return stream && *stream->token && (now - stream->started) >= timeout;
+}
+
+int fs_stream_on_body(struct fs_stream* stream, uint64_t offset, const void* data, size_t len)
+{
+	uint64_t end;
+
+	if (!stream || !*stream->token)
+		return 0;
+
+	/* Exactly where the next bytes were expected, and no further than what was
+	   asked for: a peer that answers something else is answering a question
+	   nobody put to it. */
+	if (offset != stream->want_start + stream->got)
+		return 0;
+
+	end = offset + (uint64_t) len;
+	if (end > stream->want_end)
+		return 0;
+
+	memcpy(&stream->window[offset - stream->want_start], data, len);
+	stream->got += (uint64_t) len;
+	return 1;
+}
+
+void fs_stream_on_done(struct fs_stream* stream, int ok)
+{
+	if (!stream || !*stream->token)
+		return;
+
+	stream->token[0] = '\0';
+
+	if (!ok || stream->got != (stream->want_end - stream->want_start))
+	{
+		/* A short answer is not a short file: the size came from the file list
+		   and the request was inside it, so this is a peer that stopped. */
+		stream->have_start = stream->have_end = 0;
+		stream_wake(stream, -EIO);
+		return;
+	}
+
+	stream->have_start = stream->want_start;
+	stream->have_end = stream->want_end;
+
+	/* Woken with 0: "look again", not "no bytes". The waiter re-reads from the
+	   window, which now holds what it was waiting for. */
+	stream_wake(stream, 0);
+}
+
+/** Ask the peer for the window this read wants. @return 0 or a negative errno. */
+static int stream_request(struct fs_stream* stream, uint64_t offset, size_t len)
+{
+	uint64_t end = offset + (uint64_t) len + FS_STREAM_READAHEAD;
+	int result;
+
+	if (end > stream->size)
+		end = stream->size;
+
+	if (end - offset > FS_STREAM_WINDOW)
+		end = offset + FS_STREAM_WINDOW;
+
+	if (end <= offset)
+		return -EINVAL;
+
+	result = fs_transfer_request_range(stream->transfer, stream->cid, stream->tth,
+	                                   offset, end - offset, stream->token);
+	if (result < 0)
+		return result;
+
+	stream->want_start = offset;
+	stream->want_end = end;
+	stream->got = 0;
+	stream->started = time(NULL);
+	return 0;
+}
+
+int fs_stream_read(struct fs_stream* stream, uint64_t offset, void* buf, size_t len,
+                   struct fs_task* task, int* out_got)
+{
+	uint64_t available;
+
+	*out_got = 0;
+
+	if (!stream || !buf)
+		return -EBADF;
+
+	if (offset >= stream->size)
+		return 0;   /* End of file, with out_got left at zero. */
+
+	if ((uint64_t) len > stream->size - offset)
+		len = (size_t) (stream->size - offset);
+
+	/* Already here. */
+	if (offset >= stream->have_start && offset < stream->have_end)
+	{
+		available = stream->have_end - offset;
+
+		if ((uint64_t) len > available)
+			len = (size_t) available;
+
+		memcpy(buf, &stream->window[offset - stream->have_start], len);
+		*out_got = (int) len;
+		return 0;
+	}
+
+	/* A request is out. If it covers this read, wait for it rather than
+	   cancelling it and asking again. */
+	if (*stream->token)
+	{
+		if (offset >= stream->want_start && offset < stream->want_end)
+		{
+			task->next = stream->waiters;
+			stream->waiters = task;
+			return FS_TASK_PARKED;
+		}
+
+		/* A seek somewhere else: the outstanding range is no longer wanted,
+		   but it cannot be un-asked, so it is left to arrive and be discarded
+		   rather than tangling the connection. */
+		fs_stream_abort(stream, -EAGAIN);
+	}
+
+	{
+		int result = stream_request(stream, offset, len);
+
+		if (result < 0)
+			return result;
+	}
+
+	task->next = stream->waiters;
+	stream->waiters = task;
+	return FS_TASK_PARKED;
+}

--- a/src/fuse/stream.h
+++ b/src/fuse/stream.h
@@ -1,0 +1,116 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAVE_UHUB_FUSE_STREAM_H
+#define HAVE_UHUB_FUSE_STREAM_H
+
+#include "system.h"
+#include "adc/adctypes.h"
+
+struct fs_stream;
+struct fs_task;
+struct fs_transfer;
+
+/**
+ * Reading a file too big to be worth fetching whole.
+ *
+ * Below the cache's per-file ceiling a file is downloaded in one piece,
+ * verified against its TTH and kept -- which is what makes by-tth trustworthy.
+ * Above it that is the wrong trade entirely: waiting for a whole film to arrive
+ * before the first byte can be read is not a filesystem, and a mount is not a
+ * place to store one.
+ *
+ * So a large file is read through a window instead: the range the reader asked
+ * for is requested from the peer, plus some of what it is likely to ask for
+ * next, and nothing is written to disk.
+ *
+ * WHAT THIS GIVES UP, AND WHY IT HAS TO
+ *
+ * A range cannot be verified. A TTH covers a whole file, and the leaf hashes
+ * that would let a part of one be checked (CGET tthl) are not implemented on
+ * either side of this codebase. So bytes read this way are what a peer chose to
+ * send, and the mount cannot tell you they are what you asked for -- unlike the
+ * whole-file path, where content that does not hash to its name is thrown away
+ * before any reader sees it.
+ *
+ * That is why the boundary is the cache's file size ceiling and not, say, a
+ * convenience: everything that *can* be verified still is, and streaming
+ * applies only where verification was never available. Raising max_file_size
+ * moves more content onto the verified path at the cost of holding it.
+ */
+
+/** Bytes requested beyond what a reader asked for, in anticipation. */
+#define FS_STREAM_READAHEAD (1024 * 1024)
+
+/** The most that is held in memory for one open file. */
+#define FS_STREAM_WINDOW (4 * 1024 * 1024)
+
+/**
+ * Begin reading @p tth from @p cid.
+ *
+ * @param size the file's size, as its owner's file list stated it.
+ * @return the stream, or NULL.
+ */
+extern struct fs_stream* fs_stream_open(struct fs_transfer* transfer, const char* tth,
+                                        const char* cid, uint64_t size);
+
+/**
+ * Read from the stream, fetching what is not already in the window.
+ *
+ * The byte count comes back through @p out_got rather than the return value,
+ * because a count of zero (end of file) and a wake-up meaning "the window
+ * moved, ask again" are both zero, and a reader that confused the two would
+ * either spin or stop early.
+ *
+ * @param task    the caller's task, parked while a request is outstanding.
+ * @param out_got receives the number of bytes copied, when 0 is returned.
+ * @return 0 when @p out_got is set and the read is finished, FS_TASK_PARKED
+ *         when a fetch had to be started, or a negative errno. A parked task
+ *         completing with 0 means the caller should read again.
+ */
+extern int fs_stream_read(struct fs_stream* stream, uint64_t offset, void* buf, size_t len,
+                          struct fs_task* task, int* out_got);
+
+/**
+ * Take a task off the stream, for a reader that has given up.
+ * @see fs_transfer_abandon().
+ */
+extern void fs_stream_abandon(struct fs_stream* stream, struct fs_task* task);
+
+extern void fs_stream_close(struct fs_stream* stream);
+
+/* --- called by the transfer layer --------------------------------------- */
+
+/** Body bytes for an outstanding request. @return 0 to abandon the transfer. */
+extern int fs_stream_on_body(struct fs_stream* stream, uint64_t offset,
+                             const void* data, size_t len);
+
+/** The outstanding request ended. */
+extern void fs_stream_on_done(struct fs_stream* stream, int ok);
+
+/** The token this stream's outstanding request was issued with, or "". */
+extern const char* fs_stream_token(struct fs_stream* stream);
+
+/** Give up on whatever is outstanding, and fail its waiters with @p error. */
+extern void fs_stream_abort(struct fs_stream* stream, int error);
+
+/** Has this stream's request been outstanding past @p deadline seconds? */
+extern int fs_stream_expired(struct fs_stream* stream, time_t now, int timeout);
+
+#endif /* HAVE_UHUB_FUSE_STREAM_H */

--- a/src/fuse/transfer.c
+++ b/src/fuse/transfer.c
@@ -1,0 +1,1198 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fuse/transfer.h"
+#include "fuse/bridge.h"
+#include "fuse/config.h"
+#include "fuse/filelist.h"
+#include "fuse/roster.h"
+#include "fuse/session.h"
+#include "fuse/stream.h"
+#include "network/backend.h"
+#include "network/connection.h"
+#include "network/ipcalc.h"
+#include "network/network.h"
+#include "network/tls.h"
+#include "seeder/cache.h"
+#include "seeder/cc.h"
+#include "seeder/grant.h"
+#include "util/log.h"
+#include "util/memory.h"
+
+/** Backlog for the transfer port, as uhub-seeder uses. */
+#define FS_LISTEN_BACKLOG 128
+
+/**
+ * Room for the cache directory. Matches SEED_DIR_MAX, which cache.c enforces
+ * and does not export; a longer path is refused there, so there is nothing to
+ * gain by carrying one here.
+ */
+#define FS_CACHE_DIR_MAX 256
+
+/** Wants outstanding at once. A mount is a person reading files, not a crawler. */
+#define FS_MAX_WANTS 32
+
+/** Seconds between re-asking about a hash nobody has answered for. */
+#define FS_RETRY_INTERVAL 15
+
+/** Peers whose file list is held at once. */
+#define FS_MAX_FILELISTS 8
+
+/** Large files open for reading at once. */
+#define FS_MAX_STREAMS 16
+
+/** Seconds a file list is considered current. A share changes slowly. */
+#define FS_FILELIST_TTL 300
+
+/** The file every DC client publishes its share in. */
+#define FS_FILELIST_NAME "files.xml.bz2"
+
+enum fs_want_state
+{
+	FS_WANT_FREE = 0,
+	FS_WANT_SEARCHING,   /** A BSCH is out; waiting for somebody to answer. */
+	FS_WANT_ASKED,       /** A CTM is out; waiting for the peer to dial in. */
+};
+
+/**
+ * One hash somebody is waiting for.
+ *
+ * Several readers may want the same file, so the waiters are a list: one
+ * download answers all of them. The tasks are the FUSE threads' own stack
+ * memory, chained through the `next` a parked task lends its parker.
+ */
+struct fs_want
+{
+	enum fs_want_state state;
+	char tth[SEED_TTH_STR_LEN + 1];
+	struct fs_task* waiters;
+	time_t deadline;
+	time_t next_attempt;
+	sid_t asked;         /** Who the outstanding CTM went to. */
+	uint64_t size;       /** As announced in the search result; 0 if unknown. */
+
+	/** Whom to ask before asking everybody, and whether we have. */
+	char from_cid[MAX_CID_LEN + 1];
+	int asked_source;
+};
+
+/** A file list being fetched from one peer. */
+struct fs_filelist_want
+{
+	int used;
+	char cid[MAX_CID_LEN + 1];
+	struct fs_task* waiters;
+	time_t deadline;
+};
+
+/** A file list we hold, parsed. */
+struct fs_peer_files
+{
+	char cid[MAX_CID_LEN + 1];
+	struct fs_filelist* list;
+	time_t fetched;
+};
+
+struct fs_transfer
+{
+	struct fs_session* session;
+
+	struct seed_cache* cache;
+	struct seed_grants* grants;
+	struct seed_cc_policy policy;
+	struct ssl_context_handle* tls_ctx;
+
+	struct net_connection* listener;
+	int listen_af;
+	uint16_t port;
+	char support[64];
+
+	/* The policy keeps pointers into these, so they live as long as it does. */
+	char own_cid[MAX_CID_LEN + 1];
+	char tls_version[8];
+	char* tls_ciphersuite;
+	char* tls_ciphersuites;
+
+	struct fs_stream* streams[FS_MAX_STREAMS];
+	uint64_t max_cached;
+
+	struct fs_want wants[FS_MAX_WANTS];
+	struct fs_filelist_want list_wants[FS_MAX_FILELISTS];
+	struct fs_peer_files files[FS_MAX_FILELISTS];
+	int timeout;
+};
+
+/* ------------------------------------------------------------- the wants */
+
+static struct fs_want* want_find(struct fs_transfer* t, const char* tth)
+{
+	size_t n;
+
+	for (n = 0; n < FS_MAX_WANTS; n++)
+		if (t->wants[n].state != FS_WANT_FREE && strcmp(t->wants[n].tth, tth) == 0)
+			return &t->wants[n];
+
+	return NULL;
+}
+
+static struct fs_want* want_alloc(struct fs_transfer* t)
+{
+	size_t n;
+
+	for (n = 0; n < FS_MAX_WANTS; n++)
+		if (t->wants[n].state == FS_WANT_FREE)
+			return &t->wants[n];
+
+	return NULL;
+}
+
+/** Answer everybody waiting for this hash, and let the slot go. */
+static void want_finish(struct fs_transfer* t, struct fs_want* want, int result)
+{
+	struct fs_task* task = want->waiters;
+
+	want->waiters = NULL;
+	want->state = FS_WANT_FREE;
+
+	while (task)
+	{
+		/* Read `next` before completing: the task is the waiter's stack and is
+		   gone the moment it is woken. */
+		struct fs_task* next = task->next;
+
+		task->next = NULL;
+		fs_bridge_complete(t->session->bridge, task, result);
+		task = next;
+	}
+}
+
+/**
+ * Ask one peer for a hash directly.
+ *
+ * @return 1 if the request went out.
+ */
+static int want_ask_peer(struct fs_transfer* t, struct fs_want* want, const char* cid, time_t now)
+{
+	struct fs_roster_user* user = fs_roster_by_cid(t->session->roster, cid);
+	struct fs_peer peer;
+	char token[SEED_TOKEN_MAX + 1];
+	const char* protocol;
+
+	if (!user || !fs_session_peer_by_sid(t->session, user->sid, &peer))
+		return 0;
+
+	if (!seed_cc_request_token(&t->policy, peer.cid, want->tth, want->size, NULL, token))
+		return 0;
+
+	protocol = seed_cc_protocol_for_peer(&t->policy, peer.support, NULL);
+
+	if (!fs_session_send_ctm(t->session, peer.sid, protocol, t->port, token))
+	{
+		seed_grant_release(t->grants, token);
+		return 0;
+	}
+
+	want->state = FS_WANT_ASKED;
+	want->asked = peer.sid;
+	want->next_attempt = now + FS_RETRY_INTERVAL;
+	LOG_INFO("fuse: asked %s for TTH=%s (%s)", peer.cid, want->tth, protocol);
+	return 1;
+}
+
+/**
+ * Ask the hub who has this hash.
+ *
+ * The token is the hash itself. A search result carries it back, which is what
+ * lets an answer be matched to the question without keeping a table of tokens
+ * -- and a hash is already unique among the things we are asking about.
+ */
+static void want_search(struct fs_transfer* t, struct fs_want* want, time_t now)
+{
+	want->state = FS_WANT_SEARCHING;
+	want->next_attempt = now + FS_RETRY_INTERVAL;
+	want->asked = 0;
+
+	if (!fs_session_send_search_tth(t->session, want->tth, want->tth))
+		LOG_DEBUG("fuse: unable to search for TTH=%s", want->tth);
+}
+
+/* ------------------------------------------------------------ file lists */
+
+static struct fs_peer_files* files_find(struct fs_transfer* t, const char* cid)
+{
+	size_t n;
+
+	for (n = 0; n < FS_MAX_FILELISTS; n++)
+		if (t->files[n].list && strcmp(t->files[n].cid, cid) == 0)
+			return &t->files[n];
+
+	return NULL;
+}
+
+/** A free slot, or the least recently fetched one, whose list is dropped. */
+static struct fs_peer_files* files_slot(struct fs_transfer* t)
+{
+	struct fs_peer_files* oldest = &t->files[0];
+	size_t n;
+
+	for (n = 0; n < FS_MAX_FILELISTS; n++)
+	{
+		if (!t->files[n].list)
+			return &t->files[n];
+
+		if (t->files[n].fetched < oldest->fetched)
+			oldest = &t->files[n];
+	}
+
+	fs_filelist_destroy(oldest->list);
+	memset(oldest, 0, sizeof(*oldest));
+	return oldest;
+}
+
+static struct fs_filelist_want* list_want_find(struct fs_transfer* t, const char* cid)
+{
+	size_t n;
+
+	for (n = 0; n < FS_MAX_FILELISTS; n++)
+		if (t->list_wants[n].used && strcmp(t->list_wants[n].cid, cid) == 0)
+			return &t->list_wants[n];
+
+	return NULL;
+}
+
+static void list_want_finish(struct fs_transfer* t, struct fs_filelist_want* want, int result)
+{
+	struct fs_task* task = want->waiters;
+
+	want->waiters = NULL;
+	want->used = 0;
+
+	while (task)
+	{
+		struct fs_task* next = task->next;
+
+		task->next = NULL;
+		fs_bridge_complete(t->session->bridge, task, result);
+		task = next;
+	}
+}
+
+/**
+ * Turn a downloaded file list into a tree.
+ *
+ * The compressed document is read back out of the cache and then removed from
+ * it: it is not content anybody will ask us for by hash, and a share list can
+ * be large enough to be worth not keeping twice.
+ */
+static int files_adopt(struct fs_transfer* t, const char* cid, const char* tth, uint64_t size)
+{
+	struct fs_peer_files* slot;
+	struct fs_filelist* list;
+	char* buf;
+	ssize_t got;
+	int fd;
+
+	if (!size || size > FS_FILELIST_MAX)
+	{
+		seed_cache_remove(t->cache, tth, "file list, unusable");
+		return 0;
+	}
+
+	fd = fs_transfer_open_file(t, tth, NULL);
+	if (fd < 0)
+		return 0;
+
+	buf = (char*) hub_malloc((size_t) size);
+	if (!buf)
+	{
+		fs_transfer_close_file(t, tth, fd);
+		return 0;
+	}
+
+	got = seed_cache_read(t->cache, fd, size, 0, buf, (size_t) size);
+	fs_transfer_close_file(t, tth, fd);
+
+	if (got != (ssize_t) size)
+	{
+		hub_free(buf);
+		seed_cache_remove(t->cache, tth, "file list, short read");
+		return 0;
+	}
+
+	list = fs_filelist_load(buf, (size_t) size);
+	hub_free(buf);
+	seed_cache_remove(t->cache, tth, "file list, parsed");
+
+	if (!list)
+	{
+		LOG_DEBUG("fuse: %s sent a file list that does not parse", cid);
+		return 0;
+	}
+
+	slot = files_slot(t);
+
+	/* A CID is exactly MAX_CID_LEN characters wherever it comes from, and the
+	   caller only ever passes one; anything else is not a peer we could have
+	   asked. */
+	if (strlen(cid) != MAX_CID_LEN)
+	{
+		fs_filelist_destroy(list);
+		return 0;
+	}
+
+	memcpy(slot->cid, cid, MAX_CID_LEN + 1);
+	slot->list = list;
+	slot->fetched = time(NULL);
+
+	LOG_INFO("fuse: file list from %s holds %zu entries", cid, fs_filelist_count(list));
+	return 1;
+}
+
+/* ------------------------------------------------------------- streaming */
+
+/** Whichever stream is waiting on @p token. */
+static struct fs_stream* stream_by_token(struct fs_transfer* t, const char* token)
+{
+	size_t n;
+
+	if (!token || !*token)
+		return NULL;
+
+	for (n = 0; n < FS_MAX_STREAMS; n++)
+		if (t->streams[n] && strcmp(fs_stream_token(t->streams[n]), token) == 0)
+			return t->streams[n];
+
+	return NULL;
+}
+
+static int transfer_on_body(void* ptr, const char* token, uint64_t offset,
+                            const void* data, size_t len)
+{
+	struct fs_transfer* t = (struct fs_transfer*) ptr;
+	struct fs_stream* stream = stream_by_token(t, token);
+
+	/* Nobody is waiting for this any more -- the reader seeked away, or closed
+	   the file. Answering 0 ends the transfer rather than paying for the rest
+	   of a range that will be thrown away. */
+	if (!stream)
+		return 0;
+
+	return fs_stream_on_body(stream, offset, data, len);
+}
+
+static void transfer_on_body_done(void* ptr, const char* token, int ok)
+{
+	struct fs_transfer* t = (struct fs_transfer*) ptr;
+	struct fs_stream* stream = stream_by_token(t, token);
+
+	if (stream)
+		fs_stream_on_done(stream, ok);
+}
+
+uint64_t fs_transfer_max_cached_size(struct fs_transfer* t)
+{
+	return t ? t->max_cached : 0;
+}
+
+struct fs_stream* fs_transfer_stream_open(struct fs_transfer* t, const char* tth,
+                                          const char* cid, uint64_t size)
+{
+	struct fs_stream* stream;
+	size_t n;
+
+	if (!t)
+		return NULL;
+
+	for (n = 0; n < FS_MAX_STREAMS; n++)
+		if (!t->streams[n])
+			break;
+
+	if (n == FS_MAX_STREAMS)
+		return NULL;
+
+	stream = fs_stream_open(t, tth, cid, size);
+	if (!stream)
+		return NULL;
+
+	t->streams[n] = stream;
+	return stream;
+}
+
+void fs_transfer_stream_close(struct fs_transfer* t, struct fs_stream* stream)
+{
+	size_t n;
+
+	if (!t || !stream)
+		return;
+
+	for (n = 0; n < FS_MAX_STREAMS; n++)
+	{
+		if (t->streams[n] == stream)
+		{
+			t->streams[n] = NULL;
+			break;
+		}
+	}
+
+	fs_stream_close(stream);
+}
+
+void fs_transfer_complete_task(struct fs_transfer* t, struct fs_task* task, int result)
+{
+	fs_bridge_complete(t->session->bridge, task, result);
+}
+
+int fs_transfer_request_range(struct fs_transfer* t, const char* cid, const char* tth,
+                              uint64_t start, uint64_t len, char out_token[SEED_TOKEN_MAX + 1])
+{
+	struct fs_roster_user* user;
+	struct fs_peer peer;
+	const char* protocol;
+	char token[SEED_TOKEN_MAX + 1];
+
+	if (!t)
+		return -ENODEV;
+
+	user = fs_roster_by_cid(t->session->roster, cid);
+	if (!user || !fs_session_peer_by_sid(t->session, user->sid, &peer))
+		return -ENOENT;
+
+	if (!seed_grant_make_token(token))
+		return -EAGAIN;
+
+	if (!seed_grant_issue_range(t->grants, token, cid, tth, start, len, time(NULL)))
+		return -EAGAIN;
+
+	protocol = seed_cc_protocol_for_peer(&t->policy, peer.support, NULL);
+
+	if (!fs_session_send_ctm(t->session, peer.sid, protocol, t->port, token))
+	{
+		seed_grant_release(t->grants, token);
+		return -EHOSTUNREACH;
+	}
+
+	memcpy(out_token, token, sizeof(token));
+	LOG_DEBUG("fuse: asked %s for %llu bytes of TTH=%s at %llu", cid,
+		(unsigned long long) len, tth, (unsigned long long) start);
+	return 0;
+}
+
+/* --------------------------------------------------------- the cache side */
+
+static void transfer_on_download(void* ptr, const char* tth, enum seed_error err,
+                                 const struct seed_entry* entry)
+{
+	struct fs_transfer* t = (struct fs_transfer*) ptr;
+	struct fs_want* want = want_find(t, tth);
+
+	/*
+	 * A file list has no hash to be recognised by -- that is why it was asked
+	 * for by name -- so it is attributed by who sent it. A hash that is on the
+	 * want queue is content and takes precedence; anything else from a peer we
+	 * have a list outstanding with is that list.
+	 */
+	if (!want && err == SEED_OK && entry && *entry->origin_cid)
+	{
+		struct fs_filelist_want* list_want = list_want_find(t, entry->origin_cid);
+
+		if (list_want)
+		{
+			/*
+			 * entry->tth, not the tth argument: that one is the hash the
+			 * request named, and a request made by name named none. What the
+			 * list turned out to hash to is only known now, and is the only
+			 * way to find it in the cache.
+			 */
+			int ok = files_adopt(t, entry->origin_cid, entry->tth, entry->size);
+			list_want_finish(t, list_want, ok ? 0 : -EIO);
+			return;
+		}
+	}
+
+	if (!want)
+		return;
+
+	if (err == SEED_OK)
+	{
+		LOG_INFO("fuse: TTH=%s is now cached", tth);
+		want_finish(t, want, 0);
+		return;
+	}
+
+	/* The bytes arrived and were not what was asked for, or would not fit.
+	   Another peer offering the same hash would produce the same file, so
+	   there is nothing to retry. */
+	LOG_WARN("fuse: download of TTH=%s failed (%s)", tth, seed_error_string(err));
+	want_finish(t, want, -EIO);
+}
+
+/* ------------------------------------------------------------ the listener */
+
+static void transfer_on_accept(struct net_connection* con, int events, void* arg)
+{
+	struct fs_transfer* t = (struct fs_transfer*) arg;
+	int server_fd = net_con_get_sd(con);
+
+	(void) events;
+
+	for (;;)
+	{
+		struct ip_addr_encap addr;
+		struct net_connection* client;
+		int fd = net_accept(server_fd, &addr);
+
+		if (fd == -1)
+		{
+			if (net_error() != EWOULDBLOCK)
+				LOG_ERROR("fuse: accept error: %d %s", net_error(), strerror(net_error()));
+			break;
+		}
+
+		/* Drain the backlog even while refusing, so the kernel accept queue
+		   empties and the listener stops re-firing. */
+		if (net_backend_get_num_connections() >= net_backend_get_max_connections() ||
+		    (size_t) fd >= net_backend_get_max_connections())
+		{
+			LOG_WARN("fuse: connection limit reached, rejecting connection.");
+			net_close(fd);
+			continue;
+		}
+
+		client = net_con_create();
+		if (!client)
+		{
+			net_close(fd);
+			break;
+		}
+
+		/* seed_cc_accept() reinitializes this with its own handler; the
+		   placeholder here just gets the descriptor into the backend. */
+		net_con_initialize(client, fd, transfer_on_accept, t, NET_EVENT_READ);
+
+		if (!seed_cc_accept(&t->policy, client, &addr))
+		{
+			LOG_WARN("fuse: unable to accept a connection from %s", ip_convert_to_string(&addr));
+			net_con_close(client);
+		}
+	}
+}
+
+static struct net_connection* transfer_listen(struct fs_transfer* t, const struct fs_config* cfg)
+{
+	struct net_connection* server;
+	struct sockaddr_storage addr;
+	socklen_t sockaddr_size;
+	int sd;
+
+	if (ip_convert_address(cfg->transfer_bind_addr, cfg->transfer_port,
+	                       (struct sockaddr*) &addr, &sockaddr_size) == -1)
+	{
+		LOG_FATAL("fuse: unable to resolve the bind address \"%s\".", cfg->transfer_bind_addr);
+		return NULL;
+	}
+
+	sd = net_socket_create(addr.ss_family, SOCK_STREAM, IPPROTO_TCP);
+	if (sd == -1)
+		return NULL;
+
+	if (net_set_reuseaddress(sd, 1) == -1 || net_set_nonblocking(sd, 1) == -1)
+	{
+		net_close(sd);
+		return NULL;
+	}
+
+	if (net_bind(sd, (struct sockaddr*) &addr, sockaddr_size) == -1)
+	{
+		LOG_FATAL("fuse: unable to bind to %s port %d: %s", cfg->transfer_bind_addr,
+			cfg->transfer_port, net_error_string(net_error()));
+		net_close(sd);
+		return NULL;
+	}
+
+	if (net_listen(sd, FS_LISTEN_BACKLOG) == -1)
+	{
+		LOG_FATAL("fuse: unable to listen on %s port %d.", cfg->transfer_bind_addr, cfg->transfer_port);
+		net_close(sd);
+		return NULL;
+	}
+
+	server = net_con_create();
+	if (!server)
+	{
+		net_close(sd);
+		return NULL;
+	}
+
+	net_con_initialize(server, sd, transfer_on_accept, t, NET_EVENT_READ);
+	t->listen_af = addr.ss_family;
+	return server;
+}
+
+/* ------------------------------------------------------------------- TLS */
+
+static int transfer_setup_tls(struct fs_transfer* t, const struct fs_config* cfg)
+{
+	const char* cert = cfg->tls_certificate;
+	const char* key = cfg->tls_private_key;
+
+	if (!cert || !*cert || !key || !*key)
+	{
+		/* Not fatal, but worth saying: most clients refuse a plain transfer. */
+		LOG_WARN("fuse: no tls_certificate configured; transfers are offered as plain "
+			"ADC/1.0, which many clients will not accept.");
+		return 1;
+	}
+
+	t->tls_ctx = net_ssl_context_create(cfg->tls_version, cfg->tls_ciphersuite, cfg->tls_ciphersuites);
+	if (!t->tls_ctx)
+	{
+		LOG_FATAL("fuse: unable to create a TLS context.");
+		return 0;
+	}
+
+	if (!ssl_load_certificate(t->tls_ctx, cert) ||
+	    !ssl_load_private_key(t->tls_ctx, key) ||
+	    !ssl_check_private_key(t->tls_ctx))
+	{
+		LOG_FATAL("fuse: unable to load the TLS certificate \"%s\" and key \"%s\".", cert, key);
+		return 0;
+	}
+
+	LOG_INFO("fuse: transfers offered over ADCS, using certificate: %s", cert);
+	return 1;
+}
+
+/* ------------------------------------------------------------------ setup */
+
+struct fs_transfer* fs_transfer_create(struct fs_session* session, const struct fs_config* config)
+{
+	struct fs_transfer* t;
+	struct seed_cache_config cache_cfg;
+	char cache_dir[FS_CACHE_DIR_MAX];
+
+	t = (struct fs_transfer*) hub_malloc_zero(sizeof(struct fs_transfer));
+	if (!t)
+		return NULL;
+
+	t->session = session;
+	t->timeout = config->download_timeout;
+	t->port = (uint16_t) config->transfer_port;
+
+	snprintf(t->own_cid, sizeof(t->own_cid), "%s", fs_session_own_cid(session));
+	snprintf(t->tls_version, sizeof(t->tls_version), "%s", config->tls_version ? config->tls_version : "1.2");
+	t->tls_ciphersuite = hub_strdup(config->tls_ciphersuite ? config->tls_ciphersuite : "");
+	t->tls_ciphersuites = hub_strdup(config->tls_ciphersuites ? config->tls_ciphersuites : "");
+
+	if (config->cache_dir && *config->cache_dir)
+		snprintf(cache_dir, sizeof(cache_dir), "%s", config->cache_dir);
+	else if (!fs_config_default_cache_dir(cache_dir, sizeof(cache_dir)))
+	{
+		LOG_FATAL("fuse: no cache_dir configured and neither XDG_CACHE_HOME nor HOME is set.");
+		fs_transfer_destroy(t);
+		return NULL;
+	}
+
+	memset(&cache_cfg, 0, sizeof(cache_cfg));
+	cache_cfg.dir = cache_dir;
+	cache_cfg.max_bytes = (uint64_t) config->cache_size * 1024 * 1024;
+	cache_cfg.max_file_size = (uint64_t) config->max_file_size * 1024 * 1024;
+	cache_cfg.max_entries = (size_t) config->max_entries;
+	cache_cfg.entry_ttl = 0;                /* Evict by size, not by age. */
+	cache_cfg.max_concurrent_ingest = 4;
+	/* Any type: a filesystem serves whatever file the hash names, and a mount
+	   has no curated set of media types the way a seed cache does. */
+	cache_cfg.allowed_types = "*";
+
+	t->cache = seed_cache_open(&cache_cfg);
+	if (!t->cache)
+	{
+		LOG_FATAL("fuse: unable to open the cache in %s.", cache_dir);
+		fs_transfer_destroy(t);
+		return NULL;
+	}
+
+	t->grants = seed_grants_create();
+	if (!t->grants || !transfer_setup_tls(t, config))
+	{
+		fs_transfer_destroy(t);
+		return NULL;
+	}
+
+	t->policy.cache = t->cache;
+	t->policy.grants = t->grants;
+	t->policy.cid = t->own_cid;
+	t->policy.max_concurrent_upload = 8;
+	t->policy.ingest_interval = 0;     /* We asked for these files ourselves. */
+	t->policy.ingest_per_user = 0;
+	t->policy.ingest_quota_kb = 0;
+	t->policy.tls_version = t->tls_version;
+	t->policy.tls_ciphersuite = t->tls_ciphersuite;
+	t->policy.tls_ciphersuites = t->tls_ciphersuites;
+	t->policy.ssl_ctx = t->tls_ctx;
+	t->policy.on_download = transfer_on_download;
+	t->policy.on_download_ptr = t;
+	t->policy.on_body = transfer_on_body;
+	t->policy.on_body_done = transfer_on_body_done;
+	t->policy.on_body_ptr = t;
+
+	t->max_cached = cache_cfg.max_file_size;
+
+	t->listener = transfer_listen(t, config);
+	if (!t->listener)
+	{
+		fs_transfer_destroy(t);
+		return NULL;
+	}
+
+	/* Claim only what is true: the family actually bound, and ADCS only with a
+	   certificate behind it. */
+	snprintf(t->support, sizeof(t->support), "%s%s",
+		(t->listen_af == AF_INET6) ? "TCP4,TCP6" : "TCP4",
+		t->tls_ctx ? ",ADCS,ADC0" : "");
+
+	LOG_INFO("fuse: transfers on port %d, cache in %s", config->transfer_port, cache_dir);
+	return t;
+}
+
+void fs_transfer_destroy(struct fs_transfer* t)
+{
+	size_t n;
+
+	if (!t)
+		return;
+
+	fs_transfer_abort_all(t, -ENOTCONN);
+
+	if (t->listener)
+		net_con_close(t->listener);
+
+	if (t->grants)
+		seed_grants_destroy(t->grants);
+
+	for (n = 0; n < FS_MAX_STREAMS; n++)
+		fs_stream_close(t->streams[n]);
+
+	for (n = 0; n < FS_MAX_FILELISTS; n++)
+		fs_filelist_destroy(t->files[n].list);
+
+	if (t->cache)
+		seed_cache_close(t->cache);
+
+	if (t->tls_ctx)
+		net_ssl_context_destroy(t->tls_ctx);
+
+	hub_free(t->tls_ciphersuite);
+	hub_free(t->tls_ciphersuites);
+	hub_free(t);
+}
+
+const char* fs_transfer_support(struct fs_transfer* t)
+{
+	return t ? t->support : "";
+}
+
+/* ------------------------------------------------------------- the reading */
+
+int fs_transfer_peek(struct fs_transfer* t, const char* tth, uint64_t* out_size)
+{
+	struct seed_entry entry;
+
+	if (!t || !seed_cache_peek(t->cache, tth, &entry))
+		return 0;
+
+	if (out_size)
+		*out_size = entry.size;
+
+	return 1;
+}
+
+int fs_transfer_want_from(struct fs_transfer* t, const char* tth, const char* cid,
+                          struct fs_task* task)
+{
+	struct fs_want* want;
+	time_t now = time(NULL);
+
+	if (!t)
+		return -ENODEV;
+
+	if (fs_transfer_peek(t, tth, NULL))
+		return 0;
+
+	if (seed_cache_is_blocked(t->cache, tth))
+		return -EACCES;
+
+	want = want_find(t, tth);
+	if (!want)
+	{
+		want = want_alloc(t);
+		if (!want)
+			return -EAGAIN;
+
+		memset(want, 0, sizeof(*want));
+		snprintf(want->tth, sizeof(want->tth), "%s", tth);
+		want->deadline = now + t->timeout;
+
+		if (cid && *cid)
+			snprintf(want->from_cid, sizeof(want->from_cid), "%s", cid);
+
+		/* Whoever is known to have it, before everybody who might. */
+		if (*want->from_cid)
+		{
+			want->asked_source = 1;
+
+			if (!want_ask_peer(t, want, want->from_cid, now))
+				want_search(t, want, now);
+		}
+		else
+		{
+			want_search(t, want, now);
+		}
+	}
+
+	/* Everyone waiting for this hash is answered by the one download. */
+	task->next = want->waiters;
+	want->waiters = task;
+	return FS_TASK_PARKED;
+}
+
+void fs_transfer_abandon(struct fs_transfer* t, struct fs_task* task)
+{
+	size_t n;
+
+	if (!t || !task)
+		return;
+
+	for (n = 0; n < FS_MAX_STREAMS; n++)
+		fs_stream_abandon(t->streams[n], task);
+
+	for (n = 0; n < FS_MAX_FILELISTS; n++)
+	{
+		struct fs_filelist_want* want = &t->list_wants[n];
+		struct fs_task** link = &want->waiters;
+
+		if (!want->used)
+			continue;
+
+		while (*link)
+		{
+			if (*link != task)
+			{
+				link = &(*link)->next;
+				continue;
+			}
+
+			*link = task->next;
+			task->next = NULL;
+			return;
+		}
+	}
+
+	for (n = 0; n < FS_MAX_WANTS; n++)
+	{
+		struct fs_want* want = &t->wants[n];
+		struct fs_task** link = &want->waiters;
+
+		if (want->state == FS_WANT_FREE)
+			continue;
+
+		while (*link)
+		{
+			if (*link != task)
+			{
+				link = &(*link)->next;
+				continue;
+			}
+
+			*link = task->next;
+			task->next = NULL;
+
+			/*
+			 * The fetch itself is left alone even with nobody waiting for it.
+			 * A transfer that is already under way costs nothing to finish and
+			 * the file lands in the cache, where the next reader -- very
+			 * likely the one who just pressed ^C, trying again -- finds it
+			 * without asking the hub twice.
+			 */
+			return;
+		}
+	}
+}
+
+struct fs_filelist* fs_transfer_filelist(struct fs_transfer* t, const char* cid)
+{
+	struct fs_peer_files* files;
+
+	if (!t || !cid)
+		return NULL;
+
+	files = files_find(t, cid);
+	return files ? files->list : NULL;
+}
+
+int fs_transfer_want_filelist(struct fs_transfer* t, const char* cid, struct fs_task* task)
+{
+	struct fs_filelist_want* want;
+	struct fs_peer_files* files;
+	struct fs_peer peer;
+	char token[SEED_TOKEN_MAX + 1];
+	const char* protocol;
+	time_t now;
+	size_t n;
+
+	if (!t || !cid)
+		return -ENODEV;
+
+	now = time(NULL);
+
+	files = files_find(t, cid);
+	if (files && (now - files->fetched) < FS_FILELIST_TTL)
+		return 0;
+
+	want = list_want_find(t, cid);
+	if (want)
+	{
+		task->next = want->waiters;
+		want->waiters = task;
+		return FS_TASK_PARKED;
+	}
+
+	/* Only somebody who is here can be asked. */
+	{
+		struct fs_roster_user* user = fs_roster_by_cid(t->session->roster, cid);
+
+		if (!user || !fs_session_peer_by_sid(t->session, user->sid, &peer))
+			return -ENOENT;
+	}
+
+	for (n = 0; n < FS_MAX_FILELISTS; n++)
+		if (!t->list_wants[n].used)
+			break;
+
+	if (n == FS_MAX_FILELISTS)
+		return -EAGAIN;
+
+	if (!seed_grant_make_token(token))
+		return -EAGAIN;
+
+	if (!seed_grant_issue_filelist(t->grants, token, cid, FS_FILELIST_NAME, now))
+		return -EAGAIN;
+
+	protocol = seed_cc_protocol_for_peer(&t->policy, peer.support, NULL);
+
+	if (!fs_session_send_ctm(t->session, peer.sid, protocol, t->port, token))
+	{
+		seed_grant_release(t->grants, token);
+		return -EHOSTUNREACH;
+	}
+
+	want = &t->list_wants[n];
+	memset(want, 0, sizeof(*want));
+	want->used = 1;
+	snprintf(want->cid, sizeof(want->cid), "%s", cid);
+	want->deadline = now + t->timeout;
+
+	task->next = want->waiters;
+	want->waiters = task;
+
+	LOG_INFO("fuse: asked %s for its file list (%s)", cid, protocol);
+	return FS_TASK_PARKED;
+}
+
+int fs_transfer_want(struct fs_transfer* t, const char* tth, struct fs_task* task)
+{
+	return fs_transfer_want_from(t, tth, NULL, task);
+}
+
+int fs_transfer_open_file(struct fs_transfer* t, const char* tth, uint64_t* out_size)
+{
+	struct seed_entry entry;
+	int fd;
+
+	if (!t)
+		return -ENODEV;
+
+	if (!seed_cache_lookup(t->cache, tth, &entry))
+		return -ENOENT;
+
+	/* Pin first: an eviction between the lookup and the open would leave a
+	   descriptor on a file that is no longer there. */
+	if (!seed_cache_pin(t->cache, tth))
+		return -ENOENT;
+
+	fd = seed_cache_open_file(t->cache, tth);
+	if (fd < 0)
+	{
+		seed_cache_unpin(t->cache, tth);
+		return -EIO;
+	}
+
+	if (out_size)
+		*out_size = entry.size;
+
+	return fd;
+}
+
+void fs_transfer_close_file(struct fs_transfer* t, const char* tth, int fd)
+{
+	if (!t)
+		return;
+
+	if (fd >= 0)
+		close(fd);
+
+	seed_cache_unpin(t->cache, tth);
+}
+
+ssize_t fs_transfer_read(struct fs_transfer* t, int fd, uint64_t size, uint64_t offset,
+                         void* buf, size_t len)
+{
+	return seed_cache_read(t ? t->cache : NULL, fd, size, offset, buf, len);
+}
+
+/* ------------------------------------------------------------ hub events */
+
+void fs_transfer_on_search_result(struct fs_transfer* t, sid_t from, const char* tth, uint64_t size)
+{
+	struct fs_want* want;
+	struct fs_peer peer;
+	char token[SEED_TOKEN_MAX + 1];
+	const char* protocol;
+
+	if (!t)
+		return;
+
+	want = want_find(t, tth);
+	if (!want || want->state != FS_WANT_SEARCHING)
+		return;   /* Not asked for, or already being fetched from somebody. */
+
+	if (!fs_session_peer_by_sid(t->session, from, &peer))
+		return;
+
+	want->size = size;
+
+	if (!seed_cc_request_token(&t->policy, peer.cid, tth, size, NULL, token))
+	{
+		LOG_DEBUG("fuse: no grant for TTH=%s from %s", tth, peer.cid);
+		return;
+	}
+
+	protocol = seed_cc_protocol_for_peer(&t->policy, peer.support, NULL);
+
+	if (!fs_session_send_ctm(t->session, from, protocol, t->port, token))
+	{
+		seed_grant_release(t->grants, token);
+		return;
+	}
+
+	want->state = FS_WANT_ASKED;
+	want->asked = from;
+	want->next_attempt = time(NULL) + FS_RETRY_INTERVAL;
+	LOG_INFO("fuse: asked %s for TTH=%s (%s)", peer.cid, tth, protocol);
+}
+
+void fs_transfer_on_connect_req(struct fs_transfer* t, sid_t from, const char* protocol,
+                                uint16_t port, const char* token)
+{
+	struct fs_peer peer;
+	struct seed_cc_peer target;
+
+	if (!t || !fs_session_peer_by_sid(t->session, from, &peer))
+		return;
+
+	memset(&target, 0, sizeof(target));
+	target.cid = peer.cid;
+	target.addr = &peer.addr;
+
+	if (!seed_cc_may_dial(&t->policy, &target))
+		return;
+
+	seed_cc_connect_to_peer(&t->policy, &target, protocol, port, token);
+}
+
+void fs_transfer_tick(struct fs_transfer* t)
+{
+	time_t now;
+	size_t n;
+
+	if (!t)
+		return;
+
+	now = time(NULL);
+	seed_grant_sweep(t->grants, now);
+	seed_cache_sweep(t->cache, now);
+
+	for (n = 0; n < FS_MAX_WANTS; n++)
+	{
+		struct fs_want* want = &t->wants[n];
+
+		if (want->state == FS_WANT_FREE)
+			continue;
+
+		/*
+		 * A peer that never dials in produces no failure of its own -- there
+		 * is no event for "the connection I asked for never happened" -- so
+		 * the deadline is the only thing that ends this. Without it a cat on a
+		 * hash nobody has would block for ever.
+		 */
+		if (now >= want->deadline)
+		{
+			LOG_INFO("fuse: gave up on TTH=%s", want->tth);
+			want_finish(t, want, want->state == FS_WANT_SEARCHING ? -ENOENT : -ETIMEDOUT);
+			continue;
+		}
+
+		if (now >= want->next_attempt)
+			want_search(t, want, now);
+	}
+
+	for (n = 0; n < FS_MAX_FILELISTS; n++)
+	{
+		struct fs_filelist_want* want = &t->list_wants[n];
+
+		/* One peer, one request, one deadline: there is nobody else to ask. */
+		if (want->used && now >= want->deadline)
+		{
+			LOG_INFO("fuse: %s never sent its file list", want->cid);
+			list_want_finish(t, want, -ETIMEDOUT);
+		}
+	}
+
+	for (n = 0; n < FS_MAX_STREAMS; n++)
+		if (fs_stream_expired(t->streams[n], now, t->timeout))
+			fs_stream_abort(t->streams[n], -ETIMEDOUT);
+}
+
+void fs_transfer_abort_all(struct fs_transfer* t, int error)
+{
+	size_t n;
+
+	if (!t)
+		return;
+
+	for (n = 0; n < FS_MAX_WANTS; n++)
+		if (t->wants[n].state != FS_WANT_FREE)
+			want_finish(t, &t->wants[n], error);
+
+	for (n = 0; n < FS_MAX_FILELISTS; n++)
+		if (t->list_wants[n].used)
+			list_want_finish(t, &t->list_wants[n], error);
+
+	for (n = 0; n < FS_MAX_STREAMS; n++)
+		fs_stream_abort(t->streams[n], error);
+}

--- a/src/fuse/transfer.h
+++ b/src/fuse/transfer.h
@@ -1,0 +1,214 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAVE_UHUB_FUSE_TRANSFER_H
+#define HAVE_UHUB_FUSE_TRANSFER_H
+
+#include "system.h"
+#include "adc/adctypes.h"
+
+#include "seeder/grant.h"
+
+struct fs_config;
+struct fs_filelist;
+struct fs_session;
+struct fs_stream;
+struct fs_task;
+struct fs_transfer;
+struct seed_cache;
+
+/**
+ * Getting the bytes.
+ *
+ * A read of by-tth/<hash> has to end up asking somebody on the hub for a file,
+ * which is an ADC conversation lasting seconds or minutes, on a thread the
+ * reader is not on. So an open() that misses the cache is *parked*: the FUSE
+ * thread stays blocked inside the bridge, the task is put on the want queue,
+ * and it is completed when the content arrives, when the search comes back
+ * empty, or when the clock runs out.
+ *
+ * None of the machinery under this is new. The client-to-client protocol, the
+ * TTH verification and the cache are uhub-seeder's (src/seeder/cc.c, cache.c,
+ * grant.c) and are driven here exactly as the seeder drives them: the mount
+ * listens, asks a peer to connect to it with a CTM naming a token, and CGETs
+ * the file over the connection the peer opens. That arrangement is what makes
+ * a passive peer reachable, and it is why the mount needs a port of its own.
+ *
+ * Everything here belongs to the ADC thread, with one deliberate exception
+ * documented on fs_transfer_read().
+ */
+
+/**
+ * Create the cache, the transfer port and the want queue.
+ *
+ * @param session the hub connection to ask through. Not owned.
+ * @param config  the settings. Copied where needed; need not outlive the call
+ *                except for the strings named in the cc policy, which are.
+ * @return NULL if the cache could not be opened or the port could not be bound,
+ *         with the reason logged. A mount without transfers still works; it
+ *         just cannot serve by-tth.
+ */
+extern struct fs_transfer* fs_transfer_create(struct fs_session* session,
+                                              const struct fs_config* config);
+
+extern void fs_transfer_destroy(struct fs_transfer* transfer);
+
+/**
+ * The SU feature list this mount may honestly advertise, e.g. "TCP4,ADCS".
+ *
+ * Claim only what is true: TCP4/TCP6 for the family the listener actually
+ * bound, and ADCS only when the port has a certificate to complete a handshake
+ * with. A peer that acts on a false claim gets a transfer that never connects
+ * rather than one that falls back.
+ *
+ * @return the list, valid for the lifetime of @p transfer.
+ */
+extern const char* fs_transfer_support(struct fs_transfer* transfer);
+
+/**
+ * Ask for @p tth, on behalf of a parked FUSE task.
+ *
+ * @return 0 when the content is already cached and @p task may be answered at
+ *         once, FS_TASK_PARKED when it has been queued, or a negative errno.
+ */
+extern int fs_transfer_want(struct fs_transfer* transfer, const char* tth, struct fs_task* task);
+
+/**
+ * Ask for @p tth, starting with the peer known to have it.
+ *
+ * Reading a file out of somebody's share is not the same question as reading
+ * one by hash: here we know whose it is, and asking them is both quicker and
+ * the only thing that works when nobody else on the hub holds a copy. A
+ * broadcast search is still the fallback, for a peer who has gone or will not
+ * answer.
+ *
+ * @param cid whom to ask first, or NULL to search straight away.
+ */
+extern int fs_transfer_want_from(struct fs_transfer* transfer, const char* tth,
+                                 const char* cid, struct fs_task* task);
+
+/**
+ * Take one waiter off the queue, for a reader that has given up.
+ *
+ * The task is the FUSE thread's stack and is about to go away, so it must not
+ * be left where a completion could still write to it. If it was the only thing
+ * waiting for that hash, the fetch is left running: the bytes are likely on
+ * their way, and the next reader will find them cached.
+ */
+extern void fs_transfer_abandon(struct fs_transfer* transfer, struct fs_task* task);
+
+/**
+ * Make sure we hold @p cid's file list, fetching it if we do not.
+ *
+ * A file list is asked for by name rather than by hash -- its hash cannot be
+ * known until it has arrived -- and it is asked of one peer rather than of the
+ * hub, since only they have it. Otherwise this behaves exactly like
+ * fs_transfer_want(): 0 when it is already here, FS_TASK_PARKED when the task
+ * has been queued behind a fetch, or a negative errno.
+ */
+extern int fs_transfer_want_filelist(struct fs_transfer* transfer, const char* cid,
+                                     struct fs_task* task);
+
+/**
+ * The parsed file list for @p cid, or NULL if none has been fetched.
+ *
+ * Owned by the transfer layer and valid until the list is replaced, which only
+ * happens on a later fetch.
+ */
+extern struct fs_filelist* fs_transfer_filelist(struct fs_transfer* transfer, const char* cid);
+
+/**
+ * Open a cached file for reading, and pin it so it cannot be evicted while the
+ * descriptor is open.
+ *
+ * @param out_size receives the size the cache recorded.
+ * @return a descriptor, or a negative errno.
+ */
+extern int fs_transfer_open_file(struct fs_transfer* transfer, const char* tth, uint64_t* out_size);
+
+/** Close a descriptor from fs_transfer_open_file() and release its pin. */
+extern void fs_transfer_close_file(struct fs_transfer* transfer, const char* tth, int fd);
+
+/**
+ * Read from such a descriptor.
+ *
+ * This one call is safe on a FUSE thread, and is the exception to the rule that
+ * the ADC thread owns everything: it is a pread() on a descriptor the caller
+ * already holds, clamped to a size the caller already has, and it touches no
+ * shared state (see seed_cache_read()). Keeping it off the bridge is what makes
+ * a large read cost one system call instead of a thread handover.
+ */
+extern ssize_t fs_transfer_read(struct fs_transfer* transfer, int fd, uint64_t size,
+                                uint64_t offset, void* buf, size_t len);
+
+/* --- large files, read through a window --------------------------------- */
+
+/**
+ * The largest file this mount will fetch whole, verify and cache.
+ *
+ * Anything above it is read through a stream instead, which cannot be
+ * verified; see fuse/stream.h for why that boundary is where it is.
+ */
+extern uint64_t fs_transfer_max_cached_size(struct fs_transfer* transfer);
+
+/** Open a stream for a file too large to cache. @return NULL on failure. */
+extern struct fs_stream* fs_transfer_stream_open(struct fs_transfer* transfer, const char* tth,
+                                                 const char* cid, uint64_t size);
+
+extern void fs_transfer_stream_close(struct fs_transfer* transfer, struct fs_stream* stream);
+
+/**
+ * Ask @p cid for bytes [start, start+len) of @p tth.
+ *
+ * @param out_token receives the token the answer will carry.
+ * @return 0, or a negative errno.
+ */
+extern int fs_transfer_request_range(struct fs_transfer* transfer, const char* cid,
+                                     const char* tth, uint64_t start, uint64_t len,
+                                     char out_token[SEED_TOKEN_MAX + 1]);
+
+/** Complete a parked task. For fuse/stream.c, which has no bridge of its own. */
+extern void fs_transfer_complete_task(struct fs_transfer* transfer, struct fs_task* task, int result);
+
+/** Is @p tth in the cache, and how big is it? @return 1 if it is. */
+extern int fs_transfer_peek(struct fs_transfer* transfer, const char* tth, uint64_t* out_size);
+
+/* --- events routed in from the hub connection ---------------------------- */
+
+/** A DRES answering one of our searches. */
+extern void fs_transfer_on_search_result(struct fs_transfer* transfer, sid_t from,
+                                         const char* tth, uint64_t size);
+
+/** A peer is asking us to dial it (CTM), or to dial it back (RCM). */
+extern void fs_transfer_on_connect_req(struct fs_transfer* transfer, sid_t from,
+                                       const char* protocol, uint16_t port, const char* token);
+
+/** Once a second: retries, deadlines and grant expiry. */
+extern void fs_transfer_tick(struct fs_transfer* transfer);
+
+/**
+ * Fail every parked task with @p error.
+ *
+ * Called when the mount is going away. A FUSE thread waiting for a download
+ * that will now never happen would otherwise keep the filesystem busy and the
+ * unmount blocked.
+ */
+extern void fs_transfer_abort_all(struct fs_transfer* transfer, int error);
+
+#endif /* HAVE_UHUB_FUSE_TRANSFER_H */

--- a/src/seeder/cc.c
+++ b/src/seeder/cc.c
@@ -176,6 +176,20 @@ struct seed_cc_connection
 	/* Download role. */
 	struct seed_ingest* ingest; /* live job while non-NULL */
 	char     want_tth[SEED_TTH_STR_LEN + 1];
+
+	/**
+	 * The file name asked for when the wanted thing has no hash yet -- a
+	 * peer's file list. Empty for an ordinary content-addressed download, and
+	 * exactly one of the two is ever set.
+	 */
+	char     want_file[SEED_GRANT_FILENAME_MAX];
+
+	/* A ranged download: what was asked for, and how far it has got. */
+	uint64_t want_start;
+	uint64_t want_range;   /** 0 when this is not a ranged download. */
+	int      range_done;   /** The range was delivered in full and reported. */
+	uint64_t in_offset;    /** Absolute position of the next byte expected. */
+
 	uint64_t want_size;
 	char     want_name[SEED_NAME_MAX];
 	uint64_t in_remaining; /* body bytes still to read */
@@ -245,23 +259,71 @@ static int cc_valid_tth(const char* str)
 }
 
 /*
- * A file identifier, which for the seeder is only ever "TTH/<base32 root>".
+ * A file identifier: "TTH/<base32 root>", or a plain name.
+ *
+ * Content is addressed by hash, and that is the only form this module will
+ * *serve*. A name is understood so that a download this daemon asked for by
+ * name -- a peer's file list, whose hash cannot be known before it arrives --
+ * can recognise the CSND that answers it. Which of the two a request carried
+ * is reported, never guessed at by the caller.
+ *
+ * A name is bounded, must not be a path, and must not contain a space (which
+ * would have split the ADC line before this ever saw it).
+ *
+ * @return 1 for a TTH, 2 for a name, 0 for neither.
  */
-static int cc_parse_identifier(const char* ident, char out[SEED_TTH_STR_LEN + 1])
+static int cc_parse_identifier(const char* ident, char out_tth[SEED_TTH_STR_LEN + 1],
+	char out_name[SEED_GRANT_FILENAME_MAX])
 {
-	if (!ident || strncmp(ident, "TTH/", 4) != 0)
-		return 0;
-	if (!cc_valid_tth(ident + 4))
+	size_t n;
+
+	if (!ident || !*ident)
 		return 0;
 
-	memcpy(out, ident + 4, SEED_TTH_STR_LEN);
-	out[SEED_TTH_STR_LEN] = '\0';
-	return 1;
+	if (strncmp(ident, "TTH/", 4) == 0)
+	{
+		if (!cc_valid_tth(ident + 4))
+			return 0;
+
+		memcpy(out_tth, ident + 4, SEED_TTH_STR_LEN);
+		out_tth[SEED_TTH_STR_LEN] = '\0';
+		return 1;
+	}
+
+	for (n = 0; ident[n]; n++)
+	{
+		if (n + 1 >= SEED_GRANT_FILENAME_MAX)
+			return 0;
+
+		if (ident[n] == '/' || (unsigned char) ident[n] <= 0x20)
+			return 0;
+	}
+
+	memcpy(out_name, ident, n + 1);
+	return 2;
 }
 
-/* CGET/CSND share their argument shape: "<type> <identifier> <start> <bytes>". */
+/** Was the identifier one this command is allowed to carry? */
+static int cc_identifier_ok(int kind, int allow_name)
+{
+	if (kind == 1)
+		return 1;   /* A hash is always allowed. */
+
+	return (kind == 2 && allow_name);
+}
+
+/*
+ * CGET/CSND share their argument shape: "<type> <identifier> <start> <bytes>".
+ *
+ * @p allow_name decides whether the identifier may be a plain file name rather
+ * than a hash, and it is set for a CSND only. The asymmetry is the point: a
+ * CSND answers a request this daemon made, so it may name whatever that
+ * request named, while a CGET is a peer asking us to serve -- and what we
+ * serve is content, which is addressed by hash. Letting a name through there
+ * would be inventing a namespace for peers to explore.
+ */
 static void cc_parse_transfer(struct adc_message* msg, struct seed_cc_request* req,
-	enum seed_cc_type file_type, enum seed_cc_type tthl_type)
+	enum seed_cc_type file_type, enum seed_cc_type tthl_type, int allow_name)
 {
 	char* type = adc_msg_get_argument(msg, 0);
 	char* ident = adc_msg_get_argument(msg, 1);
@@ -275,7 +337,7 @@ static void cc_parse_transfer(struct adc_message* msg, struct seed_cc_request* r
 		req->type = tthl_type;
 	}
 	else if (type && strcmp(type, "file") == 0 &&
-		cc_parse_identifier(ident, req->tth) &&
+		cc_identifier_ok(cc_parse_identifier(ident, req->tth, req->name), allow_name) &&
 		cc_parse_u64(start, &req->start) &&
 		cc_parse_length(bytes, &req->bytes))
 	{
@@ -378,18 +440,21 @@ int seed_cc_parse(const char* line, size_t length, struct seed_cc_request* out)
 			break;
 
 		case ADC_CMD_CGET:
-			cc_parse_transfer(msg, &req, SEED_CC_GET_FILE, SEED_CC_GET_TTHL);
+			cc_parse_transfer(msg, &req, SEED_CC_GET_FILE, SEED_CC_GET_TTHL, 0);
 			break;
 
 		case ADC_CMD_CSND:
-			cc_parse_transfer(msg, &req, SEED_CC_SND, SEED_CC_UNSUPPORTED);
+			cc_parse_transfer(msg, &req, SEED_CC_SND, SEED_CC_UNSUPPORTED, 1);
 			break;
 
 		case ADC_CMD_CGFI:
 		{
 			char* type = adc_msg_get_argument(msg, 0);
 			char* ident = adc_msg_get_argument(msg, 1);
-			if (type && strcmp(type, "file") == 0 && cc_parse_identifier(ident, req.tth))
+			/* CGFI asks about content, which is addressed by hash: a named
+			   identifier names nothing this can answer for. */
+			if (type && strcmp(type, "file") == 0 &&
+				cc_parse_identifier(ident, req.tth, req.name) == 1)
 				req.type = SEED_CC_GFI;
 			hub_free(type);
 			hub_free(ident);
@@ -672,6 +737,23 @@ static void seed_cc_destroy(struct seed_cc_connection* b)
 		b->ingest = NULL;
 	}
 
+	/*
+	 * A ranged download that did not finish has to say so here: there is no
+	 * ingest to fail and no entry to be absent, so this is the only place a
+	 * caller waiting on the range would hear about it -- including the case
+	 * where the peer refused before a single byte, which is why this turns on
+	 * a flag set at completion rather than on how much is left. Cleared first,
+	 * so a callback that starts another request does not see a second
+	 * completion for the old one.
+	 */
+	if (b->want_range && !b->range_done)
+	{
+		b->want_range = 0;
+
+		if (b->policy->on_body_done)
+			b->policy->on_body_done(b->policy->on_body_ptr, b->token, 0);
+	}
+
 	if (b->fd >= 0)
 	{
 		close(b->fd);
@@ -846,6 +928,15 @@ static int cc_handle_get(struct seed_cc_connection* b, const struct seed_cc_requ
 	uint64_t length = 0;
 	char line[128];
 
+	/*
+	 * Only by hash. The parser does not let a name reach a CGET at all (see
+	 * cc_parse_transfer); this says so again where it matters, because the
+	 * cost of being wrong is a peer naming files on the far side of a cache
+	 * that has no names in it.
+	 */
+	if (*req->name)
+		return cc_send_status(b, SEED_CC_STATUS_NO_FILE, "File\\snot\\savailable", 1);
+
 	if (!seed_cache_lookup(cache, req->tth, &entry) || seed_cache_is_blocked(cache, req->tth))
 		return cc_send_status(b, SEED_CC_STATUS_NO_FILE, "File\\snot\\savailable", 0);
 
@@ -962,7 +1053,18 @@ static int cc_ingest_bytes(struct seed_cc_connection* b, const char* data, size_
 	if ((uint64_t) len > b->in_remaining)
 		len = (size_t) b->in_remaining; /* the peer overran its own announcement */
 
-	if (len && seed_ingest_write(b->ingest, data, len) != 0)
+	if (b->want_range)
+	{
+		if (len && b->policy->on_body &&
+		    !b->policy->on_body(b->policy->on_body_ptr, b->token, b->in_offset, data, len))
+		{
+			seed_cc_destroy(b);
+			return 0;
+		}
+
+		b->in_offset += (uint64_t) len;
+	}
+	else if (len && seed_ingest_write(b->ingest, data, len) != 0)
 	{
 		seed_cc_destroy(b);
 		return 0;
@@ -972,6 +1074,17 @@ static int cc_ingest_bytes(struct seed_cc_connection* b, const char* data, size_
 
 	if (b->in_remaining == 0)
 	{
+		if (b->want_range)
+		{
+			b->range_done = 1;
+
+			if (b->policy->on_body_done)
+				b->policy->on_body_done(b->policy->on_body_ptr, b->token, 1);
+
+			seed_cc_destroy(b);
+			return 0;
+		}
+
 		cc_finish_ingest(b);
 		return 0;
 	}
@@ -984,20 +1097,40 @@ static int cc_handle_snd(struct seed_cc_connection* b, const struct seed_cc_requ
 	struct seed_ingest_request ireq;
 	enum seed_error error = SEED_OK;
 
-	/* Only the exact content we asked for, at the offset we asked for, and with
-	   a length stated up front: a peer must not be able to redirect the transfer
+	/* Only the exact thing we asked for, at the offset we asked for, and with a
+	   length stated up front: a peer must not be able to redirect the transfer
 	   onto something else, and "to end of file" gives nothing to check the body
-	   length against. */
-	if (strcmp(req->tth, b->want_tth) != 0 || req->start != 0 || req->bytes <= 0 ||
-		(b->want_size && (uint64_t) req->bytes > b->want_size))
+	   length against. Whichever way it was named, the answer has to use the
+	   same name. */
+	if (strcmp(req->tth, b->want_tth) != 0 || strcmp(req->name, b->want_file) != 0 ||
+		req->start != b->want_start || req->bytes <= 0 ||
+		(b->want_size && (uint64_t) req->bytes > b->want_size) ||
+		(b->want_range && (uint64_t) req->bytes != b->want_range))
 	{
 		LOG_DEBUG("seed_cc: unexpected CSND from %s", ip_convert_to_string(&b->addr));
 		seed_cc_destroy(b);
 		return 0;
 	}
 
+	/*
+	 * A range goes to the caller rather than into the cache. There is nothing
+	 * to verify it with, and storing it as cached content would mean claiming
+	 * otherwise.
+	 */
+	if (b->want_range)
+	{
+		b->in_remaining = (uint64_t) req->bytes;
+		b->in_total = (uint64_t) req->bytes;
+		b->state = CC_STATE_DL_BODY;
+		return 1;
+	}
+
 	memset(&ireq, 0, sizeof(ireq));
-	ireq.expect_tth = b->want_tth;
+
+	/* A file asked for by name has no hash to be checked against -- that is
+	   what asking by name means. What bounds it instead is the cache's own
+	   per-file ceiling, applied to the bytes that actually arrive. */
+	ireq.expect_tth = *b->want_tth ? b->want_tth : NULL;
 	ireq.announced_size = (uint64_t) req->bytes;
 	ireq.name = *b->want_name ? b->want_name : NULL;
 	ireq.origin_cid = *b->cid ? b->cid : NULL;
@@ -1139,11 +1272,32 @@ static int cc_handle_inf(struct seed_cc_connection* b, const struct seed_cc_requ
 	}
 
 	memcpy(b->want_tth, grant.tth, SEED_TTH_STR_LEN + 1);
+	memcpy(b->want_file, grant.filename, sizeof(b->want_file));
+
+	/*
+	 * Keep the token this grant was matched by. On a connection we dialled it
+	 * is already here (we quoted it ourselves); on one we accepted it arrived
+	 * in the peer's CINF and was used and dropped. A ranged download reports
+	 * its bytes under it, and a caller with more than one request outstanding
+	 * has nothing else to tell them apart by.
+	 */
+	strncpy(b->token, grant.token, SEED_TOKEN_MAX);
+	b->token[SEED_TOKEN_MAX] = '\0';
+
+	b->want_start = grant.start;
+	b->want_range = grant.length;
+	b->in_offset = grant.start;
 	b->want_size = grant.size;
 	memcpy(b->want_name, grant.name, sizeof(b->want_name));
 	b->want_name[sizeof(b->want_name) - 1] = '\0';
 
-	snprintf(line, sizeof(line), "CGET file TTH/%s 0 -1\n", b->want_tth);
+	if (*b->want_file)
+		snprintf(line, sizeof(line), "CGET file %s 0 -1\n", b->want_file);
+	else if (b->want_range)
+		snprintf(line, sizeof(line), "CGET file TTH/%s %" PRIu64 " %" PRIu64 "\n",
+			b->want_tth, b->want_start, b->want_range);
+	else
+		snprintf(line, sizeof(line), "CGET file TTH/%s 0 -1\n", b->want_tth);
 	if (!cc_queue(b, line))
 		return 0;
 

--- a/src/seeder/cc.h
+++ b/src/seeder/cc.h
@@ -109,6 +109,18 @@ struct seed_cc_request
 {
 	enum seed_cc_type type;
 	char     tth[SEED_TTH_STR_LEN + 1];  /** GET/GFI/SND identifier, "" if none. */
+
+	/**
+	 * The identifier as it appeared on the wire, when it was not a TTH: a
+	 * plain file name such as "files.xml.bz2". Empty for a TTH identifier, and
+	 * empty for anything that is neither.
+	 *
+	 * Only a download the caller itself asked for ever looks at this. A CGET
+	 * *served* by this module is answered from the cache by TTH and by nothing
+	 * else, so a named identifier arriving from a peer names nothing it can
+	 * reach.
+	 */
+	char     name[SEED_GRANT_FILENAME_MAX];
 	char     cid[SEED_CID_LEN + 1];      /** CINF ID, "" if absent. */
 	char     token[SEED_TOKEN_MAX + 1];  /** CINF TO, "" if absent. Kept ADC-escaped. */
 	int      have_base;                  /** CSUP advertised BASE. */
@@ -236,6 +248,31 @@ struct seed_cc_policy
 	 */
 	void (*on_download)(void* ptr, const char* tth, enum seed_error err, const struct seed_entry* entry);
 	void* on_download_ptr;
+
+	/**
+	 * Where the body of a *ranged* download goes.
+	 *
+	 * A range is bytes out of the middle of a file, so there is nothing to
+	 * check them against: a TTH covers a whole file, and this module asks for
+	 * no leaf hashes. They are therefore never ingested as cached content --
+	 * which would be claiming they had been verified -- and are handed to the
+	 * caller as they arrive instead.
+	 *
+	 * @param token  the token the grant was issued with, which is how the
+	 *               caller tells its outstanding requests apart.
+	 * @param offset the absolute position in the file of the first byte of
+	 *               @p data.
+	 * @return 0 to abandon the transfer.
+	 *
+	 * Both may be NULL, in which case a ranged grant is never issued and this
+	 * whole path is unreachable.
+	 */
+	int (*on_body)(void* ptr, const char* token, uint64_t offset, const void* data, size_t len);
+
+	/** The range ended: @p ok is 1 when every byte asked for arrived. */
+	void (*on_body_done)(void* ptr, const char* token, int ok);
+
+	void* on_body_ptr;
 };
 
 /**

--- a/src/seeder/grant.c
+++ b/src/seeder/grant.c
@@ -354,6 +354,78 @@ int seed_grant_issue(struct seed_grants* grants, const char* token, const char* 
 	return 1;
 }
 
+/**
+ * A file name that may be asked for by name.
+ *
+ * No '/' and no space: the first would make it a path (and a path is not what
+ * this asks for), the second would split the ADC line it goes into. Both are
+ * refused rather than escaped, because nothing legitimate needs them here.
+ */
+static int grant_valid_filename(const char* name)
+{
+	size_t n;
+
+	if (!name || !*name)
+		return 0;
+
+	for (n = 0; name[n]; n++)
+	{
+		if (n + 1 >= SEED_GRANT_FILENAME_MAX)
+			return 0;
+
+		if (name[n] == '/' || name[n] == ' ' || name[n] == '\n' || (unsigned char) name[n] < 0x20)
+			return 0;
+	}
+
+	return 1;
+}
+
+int seed_grant_issue_filelist(struct seed_grants* grants, const char* token, const char* cid,
+	const char* filename, time_t now)
+{
+	struct seed_grant_entry* entry;
+
+	if (!grant_valid_filename(filename))
+		return 0;
+
+	/* No TTH: there is none to know in advance, which is the point. */
+	if (!seed_grant_issue(grants, token, cid, NULL, now))
+		return 0;
+
+	entry = grant_lookup(grants, token);
+	if (!entry)
+		return 0;
+
+	entry->grant.is_download = 1;
+	strncpy(entry->grant.filename, filename, sizeof(entry->grant.filename) - 1);
+	entry->grant.filename[sizeof(entry->grant.filename) - 1] = '\0';
+	return 1;
+}
+
+int seed_grant_issue_range(struct seed_grants* grants, const char* token, const char* cid,
+	const char* tth, uint64_t start, uint64_t length, time_t now)
+{
+	struct seed_grant_entry* entry;
+
+	/* A zero length range is not a request for anything, and "to end of file"
+	   is what the whole-file grant is for. */
+	if (!length)
+		return 0;
+
+	if (!seed_grant_issue(grants, token, cid, tth, now))
+		return 0;
+
+	entry = grant_lookup(grants, token);
+	if (!entry)
+		return 0;
+
+	entry->grant.is_download = 1;
+	entry->grant.start = start;
+	entry->grant.length = length;
+	entry->grant.size = length;
+	return 1;
+}
+
 int seed_grant_issue_download(struct seed_grants* grants, const char* token, const char* cid,
 	const char* tth, uint64_t size, const char* name, time_t now)
 {

--- a/src/seeder/grant.h
+++ b/src/seeder/grant.h
@@ -52,6 +52,9 @@
 /** Longest token accepted. A token is echoed back to a peer, so it is bounded. */
 #define SEED_TOKEN_MAX 64
 
+/** Room for a named download's file name, including NUL. */
+#define SEED_GRANT_FILENAME_MAX 64
+
 /** Seconds a grant stays valid after it was issued. */
 #define SEED_GRANT_TTL 60
 
@@ -101,6 +104,29 @@ struct seed_grant
 	char     token[SEED_TOKEN_MAX + 1];
 	char     cid[SEED_CID_LEN + 1];      /** The peer this grant was issued to. */
 	char     tth[SEED_TTH_STR_LEN + 1];  /** Content named by the grant, "" if none. */
+
+	/**
+	 * What to ask for when the wanted thing has no hash yet: a file name such
+	 * as "files.xml.bz2". Empty for an ordinary content-addressed download.
+	 *
+	 * A grant carries one or the other and never both. The distinction decides
+	 * whether the reply is verified against a hash that was known in advance,
+	 * so it is recorded explicitly rather than inferred from the shape of a
+	 * string.
+	 */
+	char     filename[SEED_GRANT_FILENAME_MAX];
+
+	/**
+	 * A ranged download: the first byte and how many of them. @c length is 0
+	 * for the ordinary whole-file case.
+	 *
+	 * A range cannot be checked against the TTH -- a hash covers a whole file
+	 * and there is no leaf-hash support here to check a part of one with -- so
+	 * a grant records that it is one, and the transfer hands its bytes to the
+	 * caller instead of ingesting them into the cache as verified content.
+	 */
+	uint64_t start;
+	uint64_t length;
 	int      is_download;                /** The seeder connects to receive, not to serve. */
 	uint64_t size;                       /** Announced size of a download, 0 if unknown. */
 	char     name[SEED_NAME_MAX];        /** Display name of a download, "" if unknown. */
@@ -148,6 +174,38 @@ extern int seed_grant_issue(struct seed_grants* grants, const char* token, const
  */
 extern int seed_grant_issue_download(struct seed_grants* grants, const char* token, const char* cid,
                                      const char* tth, uint64_t size, const char* name, time_t now);
+
+/**
+ * Record a download grant for a file named rather than hashed: a peer's file
+ * list, which cannot be asked for by TTH because its hash is not knowable
+ * until it has been received.
+ *
+ * The reply to such a request is therefore not verified against anything, and
+ * that is the whole of the difference. What limits it is what limited it
+ * before: we chose the peer, we chose the name, and the cache's per-file
+ * ceiling bounds what arrives. A peer still cannot decide *what* is asked for,
+ * which is the property this module exists to keep.
+ *
+ * @param filename must be non-empty, free of '/' and of spaces, and short
+ *                 enough to fit; anything else is refused.
+ * @return 1 if the grant was recorded.
+ */
+extern int seed_grant_issue_filelist(struct seed_grants* grants, const char* token, const char* cid,
+                                     const char* filename, time_t now);
+
+/**
+ * Record a download grant for part of a file.
+ *
+ * For content too large to be worth holding whole -- a mount reading one page
+ * out of a film. What arrives cannot be verified against the TTH, so it is
+ * never cached as though it had been: it goes to the caller's sink and nowhere
+ * else. @see seed_cc_policy::on_body.
+ *
+ * @param length must be non-zero.
+ * @return 1 if the grant was recorded.
+ */
+extern int seed_grant_issue_range(struct seed_grants* grants, const char* token, const char* cid,
+                                  const char* tth, uint64_t start, uint64_t length, time_t now);
 
 /**
  * Look up the unexpired grant for @p token.

--- a/src/seeder/sniff.c
+++ b/src/seeder/sniff.c
@@ -168,6 +168,16 @@ int seed_sniff_type_allowed(const char* type, const char* list)
 		while (end > start && is_white_space(end[-1]))
 			end--;
 
+		/*
+		 * "*" is every type. There has to be a way to say that: a cache that
+		 * exists to serve whatever a hash names -- uhub-fuse's, where the
+		 * content is whatever file the user asked for -- has no list of types
+		 * to write down, and enumerating the ones that happen to be common
+		 * would silently refuse the rest.
+		 */
+		if ((end - start) == 1 && start[0] == '*')
+			return 1;
+
 		if ((size_t) (end - start) == type_len && memcmp(start, type, type_len) == 0)
 			return 1;
 

--- a/src/seeder/sniff.h
+++ b/src/seeder/sniff.h
@@ -68,7 +68,8 @@ extern const char* seed_sniff_media_type(const uint8_t* buf, size_t len);
  * Matching is exact and case sensitive on whole list items; a type is never
  * matched as a prefix or a substring of an item. Space and tab around an item
  * are ignored, so "image/png, image/gif" holds two types. An empty list
- * matches nothing.
+ * matches nothing, and a list item of "*" matches everything -- which is what
+ * a cache serving arbitrary content, rather than a curated set, wants.
  *
  * @param type the media type to look for, as returned by seed_sniff_media_type().
  * @param list a comma separated list of media types. NULL matches nothing.

--- a/src/tools/fuzz_filelist.c
+++ b/src/tools/fuzz_filelist.c
@@ -1,0 +1,162 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ * libFuzzer harness for uhub-fuse's file list parser.
+ *
+ * A file list is downloaded from another user over a client-to-client
+ * connection -- bytes chosen by a stranger, parsed before anything in them has
+ * been believed -- and what comes out of it becomes directory entries and file
+ * names in a mounted filesystem. That is the whole reason this harness exists:
+ * a name that escapes its directory here is a path traversal on the machine
+ * doing the mounting.
+ *
+ * The input is fed in twice: once as a decompressed document, so the fuzzer
+ * shapes the XML directly, and once as a compressed stream, so the bzip2 path
+ * and the size ceiling are exercised too.
+ *
+ * Beyond crash detection this checks the properties the filesystem relies on:
+ *
+ *   - every name is non-empty, is not "." or "..", and contains no '/' -- so a
+ *     name can only ever be one path component, inside its own directory
+ *   - every file carries a well-formed TTH, since a file that cannot be
+ *     fetched has no business being listed
+ *   - the tree is a tree: no node is its own ancestor, and the depth is bounded
+ *
+ * Build with:  cmake -B build-fuzz -DFUZZING=ON .  (clang)
+ * Run with:    ./build-fuzz/fuzz_filelist autotest/fuzz/corpus/filelist
+ */
+
+#include "system.h"
+#include "util/log.h"
+#include "util/memory.h"
+#include "util/misc.h"
+#include "fuse/filelist.h"
+
+#include <bzlib.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+/** Deeper than the parser accepts; reaching it means the bound failed. */
+#define FUZZ_MAX_DEPTH (FS_FILELIST_MAX_DEPTH + 2)
+
+static void check_name(const char* name)
+{
+	if (!name)
+		abort();
+
+	/* One component, and a real one. */
+	if (!*name || strchr(name, '/') || strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
+		abort();
+}
+
+static void check_tth(const char* tth)
+{
+	size_t n;
+
+	if (strlen(tth) != MAX_CID_LEN)
+		abort();
+
+	for (n = 0; n < MAX_CID_LEN; n++)
+		if (!is_valid_base32_char(tth[n]))
+			abort();
+}
+
+static void walk(struct fs_filelist_node* node, int depth)
+{
+	if (depth > FUZZ_MAX_DEPTH)
+		abort();
+
+	for (; node; node = node->next)
+	{
+		check_name(node->name);
+
+		if (node->is_dir)
+		{
+			/* A directory's children must point back at it, or a lookup could
+			   walk out of the subtree it was given. */
+			if (node->children && node->children->parent != node)
+				abort();
+
+			walk(node->children, depth + 1);
+		}
+		else
+		{
+			check_tth(node->tth);
+
+			if (node->children)
+				abort();   /* A file has no contents to descend into. */
+		}
+	}
+}
+
+static void exercise(struct fs_filelist* list)
+{
+	if (!list)
+		return;
+
+	walk(fs_filelist_root(list), 0);
+
+	/* Lookups the filesystem itself performs, on paths it did not choose. */
+	fs_filelist_lookup(list, "");
+	fs_filelist_lookup(list, "/");
+	fs_filelist_lookup(list, "..");
+	fs_filelist_lookup(list, "../..");
+	fs_filelist_lookup(list, "a/b/c");
+
+	fs_filelist_destroy(list);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+	static int initialized = 0;
+	char* packed;
+	unsigned int packed_len;
+
+	if (!initialized)
+	{
+		hub_set_log_verbosity(0);
+		initialized = 1;
+	}
+
+	if (!size || size > (1 << 20))
+		return 0;
+
+	/* As a document. */
+	exercise(fs_filelist_parse((const char*) data, size));
+
+	/* And as a stream: compressed here so that the decompressor sees something
+	   it can actually open, which is where its own bounds get tested. */
+	packed_len = (unsigned int) (size * 2 + 1024);
+	packed = (char*) hub_malloc(packed_len);
+	if (packed)
+	{
+		if (BZ2_bzBuffToBuffCompress(packed, &packed_len, (char*) (uintptr_t) data,
+		                             (unsigned int) size, 1, 0, 30) == BZ_OK)
+			exercise(fs_filelist_load(packed, packed_len));
+
+		hub_free(packed);
+	}
+
+	/* And as a stream that is not one. */
+	exercise(fs_filelist_load(data, size));
+
+	return 0;
+}

--- a/src/util/threads.c
+++ b/src/util/threads.c
@@ -68,6 +68,30 @@ void uhub_cond_wait(uhub_cond_t* cond, uhub_mutex_t* mutex)
 	pthread_cond_wait(cond, mutex);
 }
 
+int uhub_cond_timedwait(uhub_cond_t* cond, uhub_mutex_t* mutex, unsigned int ms)
+{
+	struct timespec deadline;
+
+	/*
+	 * CLOCK_REALTIME because that is what a condition variable uses unless it
+	 * was created with a different one, and these are created with the
+	 * defaults. A step in the wall clock therefore lengthens or shortens the
+	 * wait -- acceptable for a poll interval, which is all this is used for.
+	 */
+	clock_gettime(CLOCK_REALTIME, &deadline);
+
+	deadline.tv_sec += ms / 1000;
+	deadline.tv_nsec += (long) (ms % 1000) * 1000000L;
+
+	if (deadline.tv_nsec >= 1000000000L)
+	{
+		deadline.tv_sec++;
+		deadline.tv_nsec -= 1000000000L;
+	}
+
+	return pthread_cond_timedwait(cond, mutex, &deadline) != ETIMEDOUT;
+}
+
 void uhub_cond_signal(uhub_cond_t* cond)
 {
 	pthread_cond_signal(cond);
@@ -165,6 +189,11 @@ void uhub_cond_destroy(uhub_cond_t* cond)
 void uhub_cond_wait(uhub_cond_t* cond, uhub_mutex_t* mutex)
 {
 	SleepConditionVariableCS(cond, mutex, INFINITE);
+}
+
+int uhub_cond_timedwait(uhub_cond_t* cond, uhub_mutex_t* mutex, unsigned int ms)
+{
+	return SleepConditionVariableCS(cond, mutex, (DWORD) ms) ? 1 : 0;
 }
 
 void uhub_cond_signal(uhub_cond_t* cond)

--- a/src/util/threads.h
+++ b/src/util/threads.h
@@ -49,6 +49,19 @@ extern int uhub_mutex_trylock(uhub_mutex_t* mutex);
 extern void uhub_cond_init(uhub_cond_t* cond);
 extern void uhub_cond_destroy(uhub_cond_t* cond);
 extern void uhub_cond_wait(uhub_cond_t* cond, uhub_mutex_t* mutex);
+
+/**
+ * uhub_cond_wait() with a deadline, for a waiter that has something else to
+ * check on while it waits.
+ *
+ * Like uhub_cond_wait(), the mutex is released while blocking and held again
+ * on return, and a wake-up may be spurious -- the predicate must be re-tested
+ * either way.
+ *
+ * @param ms how long to wait for, in milliseconds.
+ * @return 1 if the wait ended in a signal, 0 if it ended in the timeout.
+ */
+extern int uhub_cond_timedwait(uhub_cond_t* cond, uhub_mutex_t* mutex, unsigned int ms);
 extern void uhub_cond_signal(uhub_cond_t* cond);
 extern void uhub_cond_broadcast(uhub_cond_t* cond);
 

--- a/test/e2e/filelist_peer.c
+++ b/test/e2e/filelist_peer.c
@@ -55,6 +55,7 @@
 #include "util/tth.h"
 
 #include <bzlib.h>
+#include <stdarg.h>
 #include <dirent.h>
 #include <sys/stat.h>
 #include <sys/socket.h>
@@ -145,6 +146,32 @@ static int scan_share(const char* dir)
 	return 1;
 }
 
+/*
+ * Append to @p buf, advancing @p n by what was actually written.
+ *
+ * snprintf() returns the length it *would* have needed, so "n += snprintf(...)"
+ * walks n past the end of the buffer as soon as anything is truncated, and the
+ * next "cap - n" underflows into a very large size. @return 0 if it did not fit.
+ */
+static int append_fmt(char* buf, size_t cap, size_t* n, const char* fmt, ...)
+{
+	va_list args;
+	int written;
+
+	if (*n >= cap)
+		return 0;
+
+	va_start(args, fmt);
+	written = vsnprintf(&buf[*n], cap - *n, fmt, args);
+	va_end(args);
+
+	if (written < 0 || (size_t) written >= cap - *n)
+		return 0;
+
+	*n += (size_t) written;
+	return 1;
+}
+
 /** Build the file list document and compress it, once. */
 static int build_list(void)
 {
@@ -153,26 +180,34 @@ static int build_list(void)
 	size_t n = 0;
 	unsigned int packed_len;
 	size_t i;
+	int ok;
 
 	xml = (char*) hub_malloc(cap);
 	if (!xml)
 		return 0;
 
-	n += snprintf(&xml[n], cap - n,
+	ok = append_fmt(xml, cap, &n,
 		"<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>\r\n"
 		"<FileListing Version=\"1\" CID=\"%s\" Base=\"/\" Generator=\"filelist_peer\">\r\n",
 		g_own_cid);
 
 	/* One directory, so that a browse has something to descend into, plus the
 	   files at the top level. */
-	n += snprintf(&xml[n], cap - n, "<Directory Name=\"Shared\">\r\n");
+	ok = ok && append_fmt(xml, cap, &n, "<Directory Name=\"Shared\">\r\n");
 
-	for (i = 0; i < g_file_count; i++)
-		n += snprintf(&xml[n], cap - n,
+	for (i = 0; ok && i < g_file_count; i++)
+		ok = append_fmt(xml, cap, &n,
 			"<File Name=\"%s\" Size=\"%llu\" TTH=\"%s\"/>\r\n",
 			g_files[i].name, (unsigned long long) g_files[i].size, g_files[i].tth);
 
-	n += snprintf(&xml[n], cap - n, "</Directory>\r\n</FileListing>\r\n");
+	ok = ok && append_fmt(xml, cap, &n, "</Directory>\r\n</FileListing>\r\n");
+
+	if (!ok)
+	{
+		fprintf(stderr, "filelist_peer: the share does not fit in one document\n");
+		hub_free(xml);
+		return 0;
+	}
 
 	packed_len = (unsigned int) (n * 2 + 1024);
 	g_list_bz2 = (char*) hub_malloc(packed_len);

--- a/test/e2e/filelist_peer.c
+++ b/test/e2e/filelist_peer.c
@@ -1,0 +1,512 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ * filelist_peer: a user on a hub with a share, for testing against.
+ *
+ * A test double for the part of a DC client that uhub-fuse's users/<cid>/files
+ * talks to, and which nothing else in this tree does: uhub-seeder serves
+ * content by hash and has no share to list, so it cannot stand in for a peer
+ * being browsed.
+ *
+ * It logs into a hub as an ordinary client, waits to be asked to connect
+ * (CTM), dials back, and answers whatever is asked for out of a directory on
+ * disk -- the file list itself, and any file in it by TTH.
+ *
+ *   filelist_peer <hub-url> <nick> <share-dir>
+ *
+ * The share is one flat directory; every file in it is published at the top
+ * level of the list. That is enough to exercise a browse, and a fixture that
+ * modelled a tree would only be modelling this one's own output.
+ *
+ * Deliberately simple: the client connection is handled with blocking reads
+ * and writes inside the event callback, which would be wrong in a daemon and
+ * is exactly right in a fixture that serves one peer at a time and must fail
+ * visibly rather than subtly.
+ */
+
+#include "system.h"
+#include "adc/adcconst.h"
+#include "adc/message.h"
+#include "adc/sid.h"
+#include "network/network.h"
+#include "network/backend.h"
+#include "network/ipcalc.h"
+#include "tools/adcclient.h"
+#include "util/log.h"
+#include "util/memory.h"
+#include "util/misc.h"
+#include "util/tth.h"
+
+#include <bzlib.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#define MAX_SHARED 64
+#define LINE_MAX_LEN 1024
+
+struct shared_file
+{
+	char name[256];
+	char path[1024];
+	char tth[MAX_CID_LEN + 1];
+	uint64_t size;
+};
+
+static struct shared_file g_files[MAX_SHARED];
+static size_t g_file_count = 0;
+static char* g_list_bz2 = NULL;
+static size_t g_list_len = 0;
+static char g_own_cid[MAX_CID_LEN + 1];
+static int g_running = 1;
+
+/* -- the share ------------------------------------------------------------- */
+
+static int hash_file(const char* path, char* tth, uint64_t* size)
+{
+	struct tth_context ctx;
+	uint8_t root[TTH_SIZE];
+	char buf[64 * 1024];
+	FILE* file = fopen(path, "rb");
+	size_t got;
+
+	if (!file)
+		return 0;
+
+	*size = 0;
+	tth_init(&ctx);
+
+	while ((got = fread(buf, 1, sizeof(buf), file)) > 0)
+	{
+		tth_update(&ctx, buf, got);
+		*size += got;
+	}
+
+	fclose(file);
+	tth_finalize(&ctx, root);
+	tth_to_string(root, tth);
+	return 1;
+}
+
+static int scan_share(const char* dir)
+{
+	struct dirent* entry;
+	DIR* handle = opendir(dir);
+
+	if (!handle)
+	{
+		fprintf(stderr, "filelist_peer: cannot open %s: %s\n", dir, strerror(errno));
+		return 0;
+	}
+
+	while ((entry = readdir(handle)) != NULL && g_file_count < MAX_SHARED)
+	{
+		struct shared_file* file = &g_files[g_file_count];
+		struct stat st;
+
+		if (entry->d_name[0] == '.')
+			continue;
+
+		snprintf(file->path, sizeof(file->path), "%s/%s", dir, entry->d_name);
+
+		if (stat(file->path, &st) != 0 || !S_ISREG(st.st_mode))
+			continue;
+
+		snprintf(file->name, sizeof(file->name), "%s", entry->d_name);
+
+		if (!hash_file(file->path, file->tth, &file->size))
+			continue;
+
+		printf("filelist_peer: sharing %s (%llu bytes) TTH=%s\n",
+			file->name, (unsigned long long) file->size, file->tth);
+		g_file_count++;
+	}
+
+	closedir(handle);
+	return 1;
+}
+
+/** Build the file list document and compress it, once. */
+static int build_list(void)
+{
+	char* xml;
+	size_t cap = 64 * 1024 + g_file_count * 512;
+	size_t n = 0;
+	unsigned int packed_len;
+	size_t i;
+
+	xml = (char*) hub_malloc(cap);
+	if (!xml)
+		return 0;
+
+	n += snprintf(&xml[n], cap - n,
+		"<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>\r\n"
+		"<FileListing Version=\"1\" CID=\"%s\" Base=\"/\" Generator=\"filelist_peer\">\r\n",
+		g_own_cid);
+
+	/* One directory, so that a browse has something to descend into, plus the
+	   files at the top level. */
+	n += snprintf(&xml[n], cap - n, "<Directory Name=\"Shared\">\r\n");
+
+	for (i = 0; i < g_file_count; i++)
+		n += snprintf(&xml[n], cap - n,
+			"<File Name=\"%s\" Size=\"%llu\" TTH=\"%s\"/>\r\n",
+			g_files[i].name, (unsigned long long) g_files[i].size, g_files[i].tth);
+
+	n += snprintf(&xml[n], cap - n, "</Directory>\r\n</FileListing>\r\n");
+
+	packed_len = (unsigned int) (n * 2 + 1024);
+	g_list_bz2 = (char*) hub_malloc(packed_len);
+
+	if (!g_list_bz2 ||
+	    BZ2_bzBuffToBuffCompress(g_list_bz2, &packed_len, xml, (unsigned int) n, 9, 0, 30) != BZ_OK)
+	{
+		hub_free(xml);
+		return 0;
+	}
+
+	g_list_len = packed_len;
+	hub_free(xml);
+
+	printf("filelist_peer: file list is %zu bytes compressed\n", g_list_len);
+	return 1;
+}
+
+/* -- the client connection ------------------------------------------------- */
+
+static int read_line(int sd, char* buf, size_t size)
+{
+	size_t n = 0;
+
+	while (n + 1 < size)
+	{
+		char c;
+		ssize_t got = recv(sd, &c, 1, 0);
+
+		if (got <= 0)
+			return 0;
+
+		if (c == '\n')
+		{
+			buf[n] = '\0';
+			return 1;
+		}
+
+		buf[n++] = c;
+	}
+
+	return 0;
+}
+
+static int send_all(int sd, const void* data, size_t len)
+{
+	const char* p = (const char*) data;
+
+	while (len)
+	{
+		ssize_t sent = send(sd, p, len, 0);
+
+		if (sent <= 0)
+			return 0;
+
+		p += sent;
+		len -= (size_t) sent;
+	}
+
+	return 1;
+}
+
+static int send_line(int sd, const char* line)
+{
+	printf("filelist_peer: --> %s", line);
+	return send_all(sd, line, strlen(line));
+}
+
+/**
+ * Answer one CGET.
+ *
+ * @param start  the first byte asked for.
+ * @param bytes  how many, or -1 for "to the end of the file".
+ * @return 1 if something was sent.
+ */
+static int serve_get(int sd, const char* ident, uint64_t start, int64_t bytes)
+{
+	char line[LINE_MAX_LEN];
+	size_t i;
+
+	if (strcmp(ident, "files.xml.bz2") == 0)
+	{
+		snprintf(line, sizeof(line), "CSND file files.xml.bz2 0 %zu\n", g_list_len);
+		return send_line(sd, line) && send_all(sd, g_list_bz2, g_list_len);
+	}
+
+	if (strncmp(ident, "TTH/", 4) != 0)
+	{
+		send_line(sd, "CSTA 151 File\\snot\\savailable\n");
+		return 1;
+	}
+
+	for (i = 0; i < g_file_count; i++)
+	{
+		FILE* file;
+		char buf[64 * 1024];
+		uint64_t remaining;
+
+		if (strcmp(&ident[4], g_files[i].tth) != 0)
+			continue;
+
+		/* A range has to be inside the file, and "to the end" means what is
+		   left from where it starts -- the same rule the seeder applies. */
+		if (start > g_files[i].size)
+		{
+			send_line(sd, "CSTA 152 File\\spart\\snot\\savailable\n");
+			return 1;
+		}
+
+		remaining = (bytes < 0) ? (g_files[i].size - start) : (uint64_t) bytes;
+
+		if (remaining > g_files[i].size - start)
+		{
+			send_line(sd, "CSTA 152 File\\spart\\snot\\savailable\n");
+			return 1;
+		}
+
+		snprintf(line, sizeof(line), "CSND file TTH/%s %llu %llu\n",
+			g_files[i].tth, (unsigned long long) start, (unsigned long long) remaining);
+
+		if (!send_line(sd, line))
+			return 0;
+
+		file = fopen(g_files[i].path, "rb");
+		if (!file)
+			return 0;
+
+		if (fseek(file, (long) start, SEEK_SET) != 0)
+		{
+			fclose(file);
+			return 0;
+		}
+
+		while (remaining)
+		{
+			size_t want = (remaining < sizeof(buf)) ? (size_t) remaining : sizeof(buf);
+			size_t got = fread(buf, 1, want, file);
+
+			if (!got || !send_all(sd, buf, got))
+			{
+				fclose(file);
+				return 0;
+			}
+
+			remaining -= got;
+		}
+
+		fclose(file);
+		return 1;
+	}
+
+	send_line(sd, "CSTA 151 File\\snot\\savailable\n");
+	return 1;
+}
+
+/**
+ * Dial a peer that asked us to, and serve it.
+ *
+ * We are the side that dialled, so we speak first and our CINF carries the
+ * token -- the same convention seeder/cc.c follows, and the one clients expect.
+ */
+static void serve_peer(const char* address, uint16_t port, const char* token)
+{
+	struct sockaddr_in addr;
+	char line[LINE_MAX_LEN];
+	int sd;
+
+	printf("filelist_peer: dialling %s:%u with token %s\n", address, (unsigned) port, token);
+
+	sd = socket(AF_INET, SOCK_STREAM, 0);
+	if (sd < 0)
+		return;
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(port);
+
+	if (inet_pton(AF_INET, address, &addr.sin_addr) != 1 ||
+	    connect(sd, (struct sockaddr*) &addr, sizeof(addr)) != 0)
+	{
+		printf("filelist_peer: cannot connect to %s:%u\n", address, (unsigned) port);
+		close(sd);
+		return;
+	}
+
+	if (!send_line(sd, "CSUP ADBASE ADTIGR\n"))
+	{
+		close(sd);
+		return;
+	}
+
+	/* Their CSUP, then their CINF, then the CGET we are here for. */
+	for (;;)
+	{
+		if (!read_line(sd, line, sizeof(line)))
+			break;
+
+		printf("filelist_peer: <-- %s\n", line);
+
+		if (strncmp(line, "CSUP", 4) == 0)
+		{
+			continue;
+		}
+		else if (strncmp(line, "CINF", 4) == 0)
+		{
+			char inf[LINE_MAX_LEN];
+			snprintf(inf, sizeof(inf), "CINF ID%s TO%s\n", g_own_cid, token);
+			if (!send_line(sd, inf))
+				break;
+		}
+		else if (strncmp(line, "CGET file ", 10) == 0)
+		{
+			char ident[512];
+			const char* pos = &line[10];
+			const char* end = strchr(pos, ' ');
+			size_t len = end ? (size_t) (end - pos) : strlen(pos);
+			uint64_t start = 0;
+			int64_t bytes = -1;
+
+			if (len >= sizeof(ident))
+				break;
+
+			memcpy(ident, pos, len);
+			ident[len] = '\0';
+
+			/* "<start> <bytes>" follow the identifier. */
+			if (end && sscanf(end + 1, "%" SCNu64 " %" SCNd64, &start, &bytes) != 2)
+			{
+				start = 0;
+				bytes = -1;
+			}
+
+			if (!serve_get(sd, ident, start, bytes))
+				break;
+		}
+		else if (strncmp(line, "CSTA", 4) == 0)
+		{
+			break;
+		}
+	}
+
+	close(sd);
+	printf("filelist_peer: connection finished\n");
+}
+
+/* -- the hub connection ---------------------------------------------------- */
+
+static int handle(struct ADC_client* client, enum ADC_client_callback_type type,
+                  struct ADC_client_callback_data* data)
+{
+	(void) client;
+
+	switch (type)
+	{
+		case ADC_CLIENT_LOGGED_IN:
+			printf("filelist_peer: logged in as CID %s\n", ADC_client_get_cid(client));
+			snprintf(g_own_cid, sizeof(g_own_cid), "%s", ADC_client_get_cid(client));
+			fflush(stdout);
+			break;
+
+		case ADC_CLIENT_CONNECT_REQ:
+			if (data && data->message)
+			{
+				char* protocol = adc_msg_get_argument(data->message, 0);
+				char* port = adc_msg_get_argument(data->message, 1);
+				char* token = adc_msg_get_argument(data->message, 2);
+
+				/* Only plain ADC: a fixture that also did TLS would be
+				   testing OpenSSL rather than the filesystem. */
+				if (protocol && port && token && strncmp(protocol, "ADC/", 4) == 0)
+					serve_peer("127.0.0.1", (uint16_t) strtoul(port, NULL, 10), token);
+				else if (protocol)
+					printf("filelist_peer: refusing protocol %s\n", protocol);
+
+				hub_free(protocol);
+				hub_free(port);
+				hub_free(token);
+				fflush(stdout);
+			}
+			break;
+
+		case ADC_CLIENT_DISCONNECTED:
+			g_running = 0;
+			break;
+
+		default:
+			break;
+	}
+
+	return 0;
+}
+
+int main(int argc, char** argv)
+{
+	struct ADC_client* client;
+
+	if (argc < 4)
+	{
+		fprintf(stderr, "Usage: %s adc://host:port <nick> <share-dir>\n", argv[0]);
+		return 1;
+	}
+
+	hub_set_log_verbosity(2);
+
+	if (!scan_share(argv[3]))
+		return 1;
+
+	net_initialize();
+
+	client = ADC_client_create(argv[2], "filelist peer", NULL);
+	if (!client)
+		return 1;
+
+	ADC_client_set_callback(client, handle);
+
+	/* TCP4 so the mount knows it can be dialled, which is what makes it send a
+	   CTM rather than give up. */
+	ADC_client_set_support(client, "TCP4");
+
+	if (!ADC_client_connect(client, argv[1]))
+	{
+		fprintf(stderr, "filelist_peer: cannot connect to %s\n", argv[1]);
+		return 1;
+	}
+
+	/* The list is built after login, since it names our own CID. */
+	while (g_running && net_backend_process())
+	{
+		if (*g_own_cid && !g_list_bz2 && !build_list())
+			break;
+	}
+
+	ADC_client_destroy(client);
+	net_destroy();
+	hub_free(g_list_bz2);
+	return 0;
+}

--- a/test/e2e/run_fuse_e2e.sh
+++ b/test/e2e/run_fuse_e2e.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# End-to-end test for uhub-fuse: mount a live hub and read it back through the
+# filesystem. Exercises what the unit tests cannot -- a real login, a real
+# roster, and the two threads answering a real kernel request.
+#
+# Usage:  BUILD=/path/to/build  test/e2e/run_fuse_e2e.sh  [port]
+# Requires (from the build dir): uhub, uhub-fuse (-DFUSE_SUPPORT=ON), adc_cmd.
+# Requires fusermount3 and permission to mount, which a container usually
+# withholds; the test skips rather than fails when it cannot mount.
+#
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../.." && pwd)
+BUILD=${BUILD:-$REPO/build}
+PORT=${1:-51031}
+HUB="adc://127.0.0.1:$PORT"
+
+UHUB=$BUILD/uhub
+FUSE=$BUILD/uhub-fuse
+ADC=$BUILD/adc_cmd
+
+for bin in "$UHUB" "$ADC"; do
+	[ -x "$bin" ] || { echo "MISSING: $bin (build it first)"; exit 2; }
+done
+[ -x "$FUSE" ] || { echo "SKIP: $FUSE not built (cmake -DFUSE_SUPPORT=ON)"; exit 77; }
+command -v fusermount3 >/dev/null || { echo "SKIP: fusermount3 not installed"; exit 77; }
+
+DIR=$(mktemp -d)
+MNT=$DIR/mnt
+mkdir -p "$MNT"
+HUB_PID=""
+FUSE_PID=""
+ALICE_PID=""
+pass=0; fail=0
+
+cleanup() {
+	fusermount3 -u "$MNT" 2>/dev/null
+	[ -n "$FUSE_PID" ] && kill "$FUSE_PID" 2>/dev/null
+	[ -n "$ALICE_PID" ] && kill "$ALICE_PID" 2>/dev/null
+	[ -n "$HUB_PID" ] && kill "$HUB_PID" 2>/dev/null
+	wait 2>/dev/null
+
+	# KEEP=1 leaves the logs behind, which is the only way to read a
+	# sanitizer report from a process this script started and then killed.
+	if [ -n "${KEEP:-}" ]; then
+		echo "== working directory kept: $DIR =="
+	else
+		rm -rf "$DIR"
+	fi
+}
+trap cleanup EXIT
+
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+is() { # description expected actual
+	if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
+}
+
+wait_for() { # command... -- retried for 10 seconds
+	local i
+	for i in $(seq 1 100); do "$@" >/dev/null 2>&1 && return 0; sleep 0.1; done
+	return 1
+}
+
+cat > "$DIR/uhub.conf" <<EOF
+server_port = $PORT
+server_bind_addr = 127.0.0.1
+tls_enable = 0
+hub_name = E2E hub
+hub_description = mounted by a test
+EOF
+
+"$UHUB" -c "$DIR/uhub.conf" >"$DIR/hub.log" 2>&1 &
+HUB_PID=$!
+if ! wait_for bash -c "exec 3<>/dev/tcp/127.0.0.1/$PORT"; then
+	echo "hub did not start listening:"; cat "$DIR/hub.log"; exit 1
+fi
+
+echo "== uhub-fuse e2e (port $PORT, workdir $DIR) =="
+
+# A second user, so users/ holds somebody other than the mount itself.
+"$ADC" "$HUB" --nick alice --expect ok --linger 120 >"$DIR/alice.log" 2>&1 &
+ALICE_PID=$!
+
+"$FUSE" --hub="$HUB" --nick=mounter -f "$MNT" >"$DIR/fuse.log" 2>&1 &
+FUSE_PID=$!
+
+if ! wait_for test -f "$MNT/hub/name"; then
+	echo "the mount did not come up:"; cat "$DIR/fuse.log"; exit 1
+fi
+ok "the hub mounts"
+
+# --- what the hub says about itself ---
+is "hub/name"        "E2E hub"            "$(cat "$MNT/hub/name")"
+is "hub/description" "mounted by a test"  "$(cat "$MNT/hub/description")"
+is "hub/address"     "$HUB"               "$(cat "$MNT/hub/address")"
+is "hub/state"       "online"             "$(cat "$MNT/hub/state")"
+is "hub/tls"         "no"                 "$(cat "$MNT/hub/tls")"
+
+wait_for bash -c "[ \"\$(cat '$MNT/hub/users')\" = 2 ]"
+is "hub/users counts both"  "2"           "$(cat "$MNT/hub/users")"
+is "me/nick"         "mounter"            "$(cat "$MNT/me/nick")"
+
+# --- users are directories named by CID ---
+count=$(ls "$MNT/users" | wc -l)
+is "users/ holds one directory per user" "2" "$count"
+
+for cid in $(ls "$MNT/users"); do
+	case "$cid" in
+		*[!A-Z2-7]* | ????????????????????????????????????????* )
+			bad "users/$cid is not a CID"; break ;;
+	esac
+done
+[ "$fail" -eq 0 ] && ok "every users/ entry is a 39 character base32 CID"
+
+ALICE="$MNT/by-nick/alice"
+if [ -L "$ALICE" ]; then ok "by-nick/alice is a symlink"; else bad "by-nick/alice is not a symlink"; fi
+target=$(readlink "$ALICE")
+linked=${target#../users/}
+if [ "$linked" != "$target" ] && [ ${#linked} -eq 39 ]; then
+	ok "the symlink names a CID under users/"
+else
+	bad "the symlink target is '$target'"
+fi
+is "following it lands on alice" "alice" "$(cat "$MNT/by-nick/alice/nick")"
+
+is "alice's nick"       "alice"     "$(cat "$ALICE/nick")"
+is "alice's ip"         "127.0.0.1" "$(cat "$ALICE/ip")"
+is "alice's share size" "0"         "$(cat "$ALICE/share_size")"
+is "an unadvertised field is empty" "" "$(cat "$ALICE/support")"
+
+# The raw line is the one the hub sent, and carries the fields the mount does
+# not model.
+if grep -q "^BINF .*NIalice" "$ALICE/inf"; then ok "users/<cid>/inf is the raw INF"; else bad "inf is not the raw line"; fi
+
+# --- a file's size has to agree with its contents ---
+size=$(stat -c %s "$ALICE/nick")
+bytes=$(wc -c < "$ALICE/nick")
+is "stat size matches what read returns" "$size" "$bytes"
+
+# --- what must not work ---
+ls "$MNT/nope"            >/dev/null 2>&1 && bad "an unknown path resolved"      || ok "an unknown path is ENOENT"
+cat "$MNT/users/AAAA"     >/dev/null 2>&1 && bad "a short CID resolved"          || ok "a malformed CID is ENOENT"
+(echo x > "$MNT/hub/name") >/dev/null 2>&1 && bad "a metadata file was writable" || ok "the mount is read-only"
+mkdir "$MNT/users/foo"    >/dev/null 2>&1 && bad "mkdir succeeded"               || ok "mkdir is refused"
+
+# --- chat ---
+echo "from the mount" > "$MNT/chat/main"
+if wait_for grep -q "<mounter> from the mount" "$MNT/chat/main"; then
+	ok "writing to chat/main says it in the hub's chat"
+else
+	bad "the message never came back (chat/main: $(cat "$MNT/chat/main"))"
+fi
+
+# One write, several messages: a newline ends each one.
+printf 'first line\nsecond line\n' > "$MNT/chat/main"
+wait_for grep -q "<mounter> second line" "$MNT/chat/main"
+lines=$(grep -c "<mounter> \(first\|second\) line" "$MNT/chat/main")
+is "a two line write is two messages" "2" "$lines"
+
+# ... and no newline at all is still a message, sent when the file is closed.
+printf 'no newline here' > "$MNT/chat/main"
+if wait_for grep -q "<mounter> no newline here" "$MNT/chat/main"; then
+	ok "a write without a newline is sent on close"
+else
+	bad "an unterminated write was never sent"
+fi
+
+"$ADC" "$HUB" --nick chatter --send "hello from chatter" --linger 2 >"$DIR/chatter.log" 2>&1
+if wait_for grep -q "<chatter> hello from chatter" "$MNT/chat/main"; then
+	ok "another user's chat arrives in chat/main"
+else
+	bad "chat from another user never arrived"
+fi
+
+# tail -f has to work, which means the size grows and reads at the end block
+# on nothing -- the log is a stream, not a snapshot.
+before=$(stat -c %s "$MNT/chat/main")
+echo "growing" > "$MNT/chat/main"
+wait_for bash -c "[ \"\$(stat -c %s '$MNT/chat/main')\" -gt $before ]"
+after=$(stat -c %s "$MNT/chat/main")
+if [ "$after" -gt "$before" ]; then ok "chat/main grows as things are said"; else bad "chat/main size stuck at $before"; fi
+
+# A private message to ourselves is not possible, so the hub's own reply to a
+# !command stands in for the receive path; it arrives as an ordinary message
+# from the hub, named rather than numbered.
+echo "!uptime" > "$MNT/chat/main"
+if wait_for grep -q "<E2E hub> \*\*\* uptime" "$MNT/chat/main"; then
+	ok "the hub speaks under its own name"
+else
+	bad "the hub's reply did not arrive (or is not named)"
+fi
+
+ALICE_CID=$(readlink "$ALICE" | sed 's|../users/||')
+echo "psst" > "$MNT/users/$ALICE_CID/msg"
+if wait_for grep -q -- "-> <alice> psst" "$MNT/chat/private"; then
+	ok "a private message is recorded in chat/private"
+else
+	bad "the outgoing private message was not recorded"
+fi
+
+cat "$MNT/users/$ALICE_CID/msg" >/dev/null 2>&1 && bad "msg was readable" || ok "msg is write-only"
+(echo x > "$MNT/chat/private") >/dev/null 2>&1 && bad "chat/private was writable" || ok "chat/private is read-only"
+
+# --- the roster follows the hub ---
+kill "$ALICE_PID" 2>/dev/null; wait "$ALICE_PID" 2>/dev/null; ALICE_PID=""
+if wait_for bash -c "[ \"\$(cat '$MNT/hub/users')\" = 1 ]"; then
+	ok "a user who leaves disappears from the mount"
+else
+	bad "the roster kept a user who left (users=$(cat "$MNT/hub/users"))"
+fi
+[ -e "$ALICE" ] && bad "by-nick kept a stale link" || ok "by-nick drops the stale link"
+
+# --- and the hub going away does not take the mount with it ---
+kill "$HUB_PID" 2>/dev/null; wait "$HUB_PID" 2>/dev/null; HUB_PID=""
+if wait_for bash -c "[ \"\$(cat '$MNT/hub/state')\" != online ]"; then
+	ok "hub/state stops saying online"
+else
+	bad "hub/state still claims online with no hub"
+fi
+is "users/ empties when the hub is gone" "0" "$(ls "$MNT/users" | wc -l)"
+ls "$MNT" >/dev/null 2>&1 && ok "the mount still answers with no hub" || bad "the mount hung when the hub went away"
+
+# --- unmount, with the process expected to leave of its own accord ---
+fusermount3 -u "$MNT"
+if wait_for bash -c "! kill -0 $FUSE_PID 2>/dev/null"; then
+	ok "unmounting stops uhub-fuse"
+	wait "$FUSE_PID" 2>/dev/null
+	is "and it exits successfully" "0" "$?"
+	FUSE_PID=""
+else
+	bad "uhub-fuse outlived its mount"
+fi
+
+if grep -qE "AddressSanitizer|runtime error:|Assertion .* failed" "$DIR/fuse.log"; then
+	bad "the mount logged a sanitizer report or an assertion:"
+	grep -E "AddressSanitizer|runtime error:|Assertion .* failed" "$DIR/fuse.log" | head -3
+else
+	ok "no sanitizer reports or assertions"
+fi
+
+echo
+echo "== $pass passed, $fail failed =="
+[ "$fail" -eq 0 ]

--- a/test/e2e/run_fuse_transfer_e2e.sh
+++ b/test/e2e/run_fuse_transfer_e2e.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+#
+# End-to-end test for uhub-fuse's by-tth: a file is read out of the mount that
+# nothing on this machine has except another process on the hub.
+#
+# This is the client-to-client path -- search, CTM, CSUP/CINF/CGET/CSND, TTH
+# verification, cache -- driven all the way through by a cat(1). The note at the
+# top of test/seeder/e2e.sh says that path could not be automated because
+# nothing could put content into a cache without a real DC client; seed_put is
+# that missing piece, and this is what it unlocks.
+#
+# The source of the file is uhub-seeder, which is what a mount would fetch from
+# on a real hub, and the two speak nothing but ordinary ADC to each other.
+#
+# Usage:  BUILD=/path/to/build  test/e2e/run_fuse_transfer_e2e.sh  [port]
+# Requires: uhub, uhub-fuse (-DFUSE_SUPPORT=ON), uhub-seeder, uhub-passwd,
+#           seed_put, mod_auth_sqlite.so, fusermount3.
+#
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../.." && pwd)
+BUILD=${BUILD:-$REPO/build}
+PORT=${1:-51051}
+SEED_PORT=$((PORT + 1))
+FUSE_PORT=$((PORT + 2))
+HUB="adc://127.0.0.1:$PORT"
+
+UHUB=$BUILD/uhub
+FUSE=$BUILD/uhub-fuse
+SEEDER=$BUILD/uhub-seeder
+PASSWD=$BUILD/uhub-passwd
+SEED_PUT=$BUILD/seed_put
+PEER=$BUILD/filelist_peer
+
+[ -x "$UHUB" ] || { echo "MISSING: $UHUB"; exit 2; }
+[ -x "$FUSE" ] || { echo "SKIP: $FUSE not built (cmake -DFUSE_SUPPORT=ON)"; exit 77; }
+for bin in "$SEEDER" "$PASSWD" "$SEED_PUT" "$PEER"; do
+	[ -x "$bin" ] || { echo "MISSING: $bin (build it first)"; exit 2; }
+done
+[ -f "$BUILD/mod_auth_sqlite.so" ] || { echo "MISSING: $BUILD/mod_auth_sqlite.so"; exit 2; }
+command -v fusermount3 >/dev/null || { echo "SKIP: fusermount3 not installed"; exit 77; }
+
+DIR=$(mktemp -d)
+MNT=$DIR/mnt
+mkdir -p "$MNT" "$DIR/cache-seeder" "$DIR/cache-mount" "$DIR/plugins" "$DIR/share"
+HUB_PID=""; SEED_PID=""; FUSE_PID=""; PEER_PID=""
+pass=0; fail=0
+
+cleanup() {
+	fusermount3 -u "$MNT" 2>/dev/null
+	for p in "$FUSE_PID" "$PEER_PID" "$SEED_PID" "$HUB_PID"; do
+		[ -n "$p" ] && kill "$p" 2>/dev/null
+	done
+	wait 2>/dev/null
+
+	# KEEP=1 leaves the logs behind, which is the only way to read a
+	# sanitizer report from a process this script started and then killed.
+	if [ -n "${KEEP:-}" ]; then
+		echo "== working directory kept: $DIR =="
+	else
+		rm -rf "$DIR"
+	fi
+}
+trap cleanup EXIT
+
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1"; fail=$((fail+1)); }
+is()  { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi; }
+
+wait_for() { local i; for i in $(seq 1 150); do "$@" >/dev/null 2>&1 && return 0; sleep 0.1; done; return 1; }
+
+# The hub refuses a group- or world-writable plugin, and a build directory
+# often is one. Copy it somewhere it can be trusted from.
+cp "$BUILD/mod_auth_sqlite.so" "$DIR/plugins/" && chmod 755 "$DIR/plugins" && chmod 644 "$DIR/plugins/mod_auth_sqlite.so"
+
+"$PASSWD" "$DIR/users.db" create >/dev/null 2>&1
+"$PASSWD" "$DIR/users.db" add seedbot seedpass operator >/dev/null 2>&1
+
+cat > "$DIR/plugins.conf" <<EOF
+plugin $DIR/plugins/mod_auth_sqlite.so "file=$DIR/users.db"
+EOF
+
+cat > "$DIR/uhub.conf" <<EOF
+server_port = $PORT
+server_bind_addr = 127.0.0.1
+tls_enable = 0
+hub_name = Transfer hub
+file_plugins = $DIR/plugins.conf
+EOF
+
+cat > "$DIR/seeder.conf" <<EOF
+seed_hub_url = $HUB
+seed_nick = seedbot
+seed_password = seedpass
+seed_client_port = $SEED_PORT
+seed_client_bind_addr = 127.0.0.1
+seed_cache_dir = $DIR/cache-seeder
+seed_allowed_types = *
+seed_bbs_enable = 0
+EOF
+
+# max_file_size is deliberately small: anything above it is read through a
+# window instead of being fetched whole, and that path needs exercising.
+cat > "$DIR/fuse.conf" <<EOF
+hub = $HUB
+nick = reader
+transfer_port = $FUSE_PORT
+transfer_bind_addr = 127.0.0.1
+cache_dir = $DIR/cache-mount
+max_file_size = 1
+download_timeout = 20
+EOF
+chmod 600 "$DIR/fuse.conf"
+
+echo "== uhub-fuse transfer e2e (hub $PORT, seeder $SEED_PORT, mount $FUSE_PORT) =="
+
+# The file to be fetched. Random, so nothing can produce it except by having it.
+head -c 300000 /dev/urandom > "$DIR/payload.bin"
+TTH=$("$SEED_PUT" "$DIR/cache-seeder" "$DIR/payload.bin" payload.bin)
+if [ ${#TTH} -eq 39 ]; then ok "seed_put put a file in a cache (TTH=$TTH)"; else bad "seed_put failed"; exit 1; fi
+
+"$UHUB" -c "$DIR/uhub.conf" >"$DIR/hub.log" 2>&1 &
+HUB_PID=$!
+wait_for bash -c "exec 3<>/dev/tcp/127.0.0.1/$PORT" || { echo "hub did not start:"; cat "$DIR/hub.log"; exit 1; }
+
+"$SEEDER" -c "$DIR/seeder.conf" >"$DIR/seeder.log" 2>&1 &
+SEED_PID=$!
+if wait_for grep -q "logged in" "$DIR/seeder.log"; then
+	ok "the seeder is on the hub holding the file"
+else
+	bad "the seeder did not log in"; cat "$DIR/seeder.log"; exit 1
+fi
+
+"$FUSE" --config="$DIR/fuse.conf" -f "$MNT" >"$DIR/fuse.log" 2>&1 &
+FUSE_PID=$!
+wait_for test -f "$MNT/hub/name" || { echo "the mount did not come up:"; cat "$DIR/fuse.log"; exit 1; }
+ok "the mount is up"
+
+# It has to be dialable, or a passive peer could never hand it anything.
+support=$(cat "$MNT/me/support")
+case "$support" in
+	*TCP4*) ok "the mount advertises TCP4, so peers will dial it" ;;
+	*) bad "me/support is '$support' -- the mount looks passive" ;;
+esac
+
+# by-tth has no listing: a content addressed directory has nothing to enumerate.
+is "by-tth lists nothing" "" "$(ls "$MNT/by-tth")"
+
+# The whole point. Nothing local has this file; the bytes come off the hub.
+if cat "$MNT/by-tth/$TTH" > "$DIR/got.bin" 2>"$DIR/cat.err"; then
+	ok "cat by-tth/<hash> succeeds"
+else
+	bad "cat failed: $(cat "$DIR/cat.err")"
+fi
+
+if cmp -s "$DIR/payload.bin" "$DIR/got.bin"; then
+	ok "the bytes are the file, exactly"
+else
+	bad "the bytes differ (got $(stat -c %s "$DIR/got.bin" 2>/dev/null || echo 0) of $(stat -c %s "$DIR/payload.bin"))"
+fi
+
+# It really did come over the wire, rather than out of a cache that already had it.
+if grep -q "accepted TTH=$TTH" "$DIR/fuse.log"; then
+	ok "the file was fetched over a client-to-client transfer"
+else
+	bad "no transfer happened -- was it already cached?"
+fi
+
+# Once cached, stat() knows how big it is and a read costs nothing.
+is "stat reports the true size once cached" "300000" "$(stat -c %s "$MNT/by-tth/$TTH")"
+is "a second read returns the same bytes" "300000" "$(cat "$MNT/by-tth/$TTH" | wc -c)"
+
+# A hash nobody has must end, and end as ENOENT rather than as a hang.
+start=$SECONDS
+cat "$MNT/by-tth/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" >/dev/null 2>&1 && bad "an unheld hash succeeded" || ok "an unheld hash fails"
+elapsed=$((SECONDS - start))
+if [ "$elapsed" -ge 15 ] && [ "$elapsed" -le 40 ]; then
+	ok "it gives up after the configured timeout (${elapsed}s)"
+else
+	bad "gave up after ${elapsed}s, expected about 20"
+fi
+
+# A pending fetch must not stop the rest of the filesystem from working.
+cat "$MNT/by-tth/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" >/dev/null 2>&1 &
+PENDING=$!
+sleep 1
+if timeout 5 ls "$MNT/users" >/dev/null 2>&1; then
+	ok "the mount answers while a download is pending"
+else
+	bad "a pending download blocked the whole mount"
+fi
+kill "$PENDING" 2>/dev/null; wait "$PENDING" 2>/dev/null
+
+# --- browsing somebody's share -------------------------------------------
+#
+# A different peer entirely: uhub-seeder serves content by hash and publishes
+# no file list, so browsing needs somebody who does. filelist_peer is that,
+# and is as close to a real DC client as a fixture gets.
+
+echo "hello from the share" > "$DIR/share/hello.txt"
+head -c 50000 /dev/urandom > "$DIR/share/blob.bin"
+head -c 5000000 /dev/urandom > "$DIR/share/big.bin"
+
+"$PEER" "$HUB" sharer "$DIR/share" >"$DIR/peer.log" 2>&1 &
+PEER_PID=$!
+if wait_for grep -q "logged in as CID" "$DIR/peer.log"; then
+	ok "a peer with a share is on the hub"
+else
+	bad "the share peer did not log in"; cat "$DIR/peer.log"
+fi
+
+wait_for test -L "$MNT/by-nick/sharer"
+SHARER=$(readlink "$MNT/by-nick/sharer" 2>/dev/null | sed 's|../users/||')
+if [ -n "$SHARER" ]; then ok "the peer appears in the mount"; else bad "the peer never appeared"; fi
+
+# Stat'ing users/<cid>/ must not fetch a share list: `ls -l` on a user
+# directory would otherwise start a download per user.
+before=$(grep -c "asked .* for its file list" "$DIR/fuse.log" || true)
+ls -l "$MNT/users/$SHARER/" >/dev/null 2>&1
+after=$(grep -c "asked .* for its file list" "$DIR/fuse.log" || true)
+is "listing a user does not fetch their share list" "$before" "$after"
+
+# Listing files/ does.
+entries=$(ls "$MNT/users/$SHARER/files/" 2>/dev/null | tr '\n' ' ')
+is "the share lists its top level" "Shared " "$entries"
+
+entries=$(ls "$MNT/users/$SHARER/files/Shared/" 2>/dev/null | sort | tr '\n' ' ')
+is "and the directory below it" "big.bin blob.bin hello.txt " "$entries"
+
+is "a shared file's size is what the list said" "50000" \
+   "$(stat -c %s "$MNT/users/$SHARER/files/Shared/blob.bin")"
+
+# The point of all of it: read a file out of somebody else's share, by name.
+if [ "$(cat "$MNT/users/$SHARER/files/Shared/hello.txt")" = "hello from the share" ]; then
+	ok "a file in the share reads back correctly"
+else
+	bad "reading a shared file gave the wrong bytes"
+fi
+
+if cat "$MNT/users/$SHARER/files/Shared/blob.bin" > "$DIR/blob.got" 2>/dev/null &&
+   cmp -s "$DIR/share/blob.bin" "$DIR/blob.got"; then
+	ok "a binary file in the share is byte for byte the same"
+else
+	bad "the binary file differs"
+fi
+
+# It is asked of the peer that has it, not broadcast to the hub: we know whose
+# share it is.
+if grep -q "asked $SHARER for TTH=" "$DIR/fuse.log"; then
+	ok "the file was asked of the peer that has it"
+else
+	bad "the mount searched the hub for a file it knew the owner of"
+fi
+
+ls "$MNT/users/$SHARER/files/Shared/nope" >/dev/null 2>&1 && bad "a missing entry resolved" || ok "a missing entry is ENOENT"
+ls "$MNT/users/$SHARER/files/Shared/hello.txt/deeper" >/dev/null 2>&1 && bad "a path below a file resolved" || ok "a path below a file is refused"
+
+# --- a file too large to hold -------------------------------------------
+#
+# Above max_file_size a file is read through a sliding window: ranged requests,
+# nothing written to disk. It cannot be verified against its hash -- a TTH
+# covers a whole file -- which is exactly why the boundary is where it is.
+
+if cat "$MNT/users/$SHARER/files/Shared/big.bin" > "$DIR/big.got" 2>/dev/null &&
+   cmp -s "$DIR/share/big.bin" "$DIR/big.got"; then
+	ok "a file larger than the cache ceiling reads back byte for byte"
+else
+	bad "the streamed file differs (got $(stat -c %s "$DIR/big.got" 2>/dev/null || echo 0))"
+fi
+
+ranges=$(grep -cE "CGET file TTH/[A-Z0-9]+ [0-9]+ [0-9]+$" "$DIR/fuse.log" || true)
+if [ "$ranges" -ge 2 ]; then
+	ok "it was fetched in ranges ($ranges of them), not in one piece"
+else
+	bad "expected several ranged requests, saw $ranges"
+fi
+
+# Streamed content is not cached: it was never verified, so storing it as
+# though it had been would be a lie. Read the hash out of the peer's own
+# listing rather than assuming one -- an empty pattern here would match every
+# ingest line and quietly pass.
+BIG_TTH=$(grep -oE "sharing big\.bin .*TTH=[A-Z0-9]+" "$DIR/peer.log" | sed 's/.*TTH=//')
+if [ ${#BIG_TTH} -ne 39 ]; then
+	bad "could not read the streamed file's TTH from the peer"
+elif [ -z "$(grep "accepted TTH=$BIG_TTH" "$DIR/fuse.log" 2>/dev/null)" ]; then
+	ok "streamed content is not cached"
+else
+	bad "a streamed file was cached as verified content"
+fi
+
+# Seeking has to work, or half of what a filesystem is for is missing.
+dd if="$MNT/users/$SHARER/files/Shared/big.bin" bs=1 skip=4000000 count=64 \
+	of="$DIR/seek.got" 2>/dev/null
+dd if="$DIR/share/big.bin" bs=1 skip=4000000 count=64 of="$DIR/seek.want" 2>/dev/null
+if cmp -s "$DIR/seek.want" "$DIR/seek.got"; then
+	ok "reading from the middle of a streamed file gives the right bytes"
+else
+	bad "a seek into a streamed file gave the wrong bytes"
+fi
+
+kill "$PEER_PID" 2>/dev/null; wait "$PEER_PID" 2>/dev/null; PEER_PID=""
+
+# A reader that gives up must be let go, rather than held for the rest of the
+# timeout. This is what makes ^C on a download work.
+cat "$MNT/by-tth/CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC" >/dev/null 2>&1 &
+PENDING=$!
+sleep 1
+start=$SECONDS
+# SIGTERM rather than SIGINT: a background job of a non-interactive shell has
+# SIGINT ignored, so ^C's signal would never reach it here. Either way it is a
+# fatal signal, which is what makes the kernel interrupt the request.
+kill -TERM "$PENDING" 2>/dev/null
+if wait_for bash -c "! kill -0 $PENDING 2>/dev/null"; then
+	elapsed=$((SECONDS - start))
+	if [ "$elapsed" -le 5 ]; then
+		ok "interrupting a pending download returns at once (${elapsed}s)"
+	else
+		bad "an interrupted reader waited ${elapsed}s"
+	fi
+else
+	bad "an interrupted reader never returned"
+fi
+wait "$PENDING" 2>/dev/null
+
+# With nothing in flight the unmount goes through. (A request still in flight
+# makes umount(2) report EBUSY, exactly as it does for any other filesystem
+# with a file open on it -- that is the kernel's rule, not this one's.)
+if timeout 15 fusermount3 -u "$MNT"; then
+	ok "the mount unmounts"
+else
+	bad "the unmount failed"
+fi
+
+if wait_for bash -c "! kill -0 $FUSE_PID 2>/dev/null"; then
+	ok "uhub-fuse exits after the unmount"
+	wait "$FUSE_PID" 2>/dev/null
+	status=$?
+	FUSE_PID=""
+
+	# Not just gone: gone cleanly. A crash on the way out still ends the
+	# process, and checking only that it ended would call that a pass.
+	is "and it exits successfully" "0" "$status"
+else
+	bad "uhub-fuse outlived its mount"
+fi
+
+# Anything the sanitizers or an assertion had to say is a failure, whatever
+# the exit status was.
+if grep -qE "AddressSanitizer|runtime error:|Assertion .* failed" "$DIR/fuse.log"; then
+	bad "the mount logged a sanitizer report or an assertion:"
+	grep -E "AddressSanitizer|runtime error:|Assertion .* failed" "$DIR/fuse.log" | head -3
+else
+	ok "no sanitizer reports or assertions"
+fi
+
+echo
+echo "== $pass passed, $fail failed =="
+[ "$fail" -eq 0 ]

--- a/test/e2e/seed_put.c
+++ b/test/e2e/seed_put.c
@@ -1,0 +1,143 @@
+/*
+ * uhub - A tiny ADC p2p connection hub
+ * Copyright (C) 2007-2026, Jan Vidar Krey
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ * seed_put: put a local file into a seed cache, and print its TTH.
+ *
+ * A test fixture, not a tool. Everything that serves content -- uhub-seeder's
+ * transfer port, uhub-fuse's by-tth -- serves it *out of a cache*, and until
+ * now nothing could put anything *into* one without a real DC client on the
+ * other end of a real transfer (see the note at the top of test/seeder/e2e.sh,
+ * which says as much). That left the whole client-to-client path untestable
+ * from a script.
+ *
+ * This does the one thing that was missing: opens a cache directory, ingests a
+ * file through the same seed_ingest_* path a download uses, and prints the TTH
+ * the content hashed to. From there a script can ask a hub for that hash and
+ * check that what comes back is the file it started with.
+ *
+ *   seed_put <cache-dir> <file> [name]
+ *
+ * Prints the TTH on stdout. Exits 0 on success, 1 on failure.
+ */
+
+#include "system.h"
+#include "seeder/cache.h"
+#include "util/log.h"
+#include "util/memory.h"
+
+#define CHUNK 65536
+
+static int put(struct seed_cache* cache, const char* path, const char* name)
+{
+	struct seed_ingest_request req;
+	struct seed_ingest* job;
+	struct seed_entry entry;
+	enum seed_error err = SEED_OK;
+	char buf[CHUNK];
+	FILE* file;
+	size_t got;
+
+	file = fopen(path, "rb");
+	if (!file)
+	{
+		fprintf(stderr, "seed_put: cannot open %s: %s\n", path, strerror(errno));
+		return 0;
+	}
+
+	memset(&req, 0, sizeof(req));
+	req.expect_tth = NULL;   /* Whatever it hashes to is the answer. */
+	req.name = name;
+	req.origin_nick = "seed_put";
+
+	job = seed_ingest_begin(cache, &req, &err);
+	if (!job)
+	{
+		fprintf(stderr, "seed_put: cannot begin: %s\n", seed_error_string(err));
+		fclose(file);
+		return 0;
+	}
+
+	while ((got = fread(buf, 1, sizeof(buf), file)) > 0)
+	{
+		int rc = seed_ingest_write(job, buf, got);
+		if (rc != 0)
+		{
+			fprintf(stderr, "seed_put: write failed: %s\n", seed_error_string((enum seed_error) -rc));
+			seed_ingest_abort(job, (enum seed_error) -rc);
+			fclose(file);
+			return 0;
+		}
+	}
+
+	if (ferror(file))
+	{
+		fprintf(stderr, "seed_put: read error on %s\n", path);
+		seed_ingest_abort(job, SEED_ERR_IO);
+		fclose(file);
+		return 0;
+	}
+
+	fclose(file);
+
+	if (!seed_ingest_finish(job, &entry, &err))
+	{
+		fprintf(stderr, "seed_put: cannot finish: %s\n", seed_error_string(err));
+		return 0;
+	}
+
+	printf("%s\n", entry.tth);
+	return 1;
+}
+
+int main(int argc, char** argv)
+{
+	struct seed_cache_config cfg;
+	struct seed_cache* cache;
+	int ok;
+
+	if (argc < 3)
+	{
+		fprintf(stderr, "Usage: %s <cache-dir> <file> [name]\n", argv[0]);
+		return 1;
+	}
+
+	hub_set_log_verbosity(2);
+
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.dir = argv[1];
+	cfg.max_bytes = (uint64_t) 1024 * 1024 * 1024;
+	cfg.max_file_size = (uint64_t) 1024 * 1024 * 1024;
+	cfg.max_entries = 4096;
+	cfg.entry_ttl = 0;
+	cfg.max_concurrent_ingest = 1;
+	cfg.allowed_types = "*";    /* A fixture is not the place to filter types. */
+
+	cache = seed_cache_open(&cfg);
+	if (!cache)
+	{
+		fprintf(stderr, "seed_put: cannot open the cache in %s\n", argv[1]);
+		return 1;
+	}
+
+	ok = put(cache, argv[2], (argc > 3) ? argv[3] : NULL);
+
+	seed_cache_close(cache);
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
New uhub-fuse, an optional client that mounts a hub as a directory tree. Built on tools/adcclient.c like uhub-seeder, and driving the seeder's transfer machinery rather than reimplementing it.

Features:

  * hub/, me/, users/<CID>/ (one directory per user, named by CID) and by-nick/ symlinks. One value per file, plus the raw INF line.
  * chat/main to read, tail and write; chat/private and users/<CID>/msg for private messages.
  * users/<CID>/files/ browses a peer's share, read through its bzip2'd XML file list; by-tth/<hash> reads any file on the hub by hash.
  * Files up to max_file_size are fetched whole, verified against the hash that named them and cached; larger ones are read through a sliding window with ranged requests, which cannot be verified since a TTH covers a whole file. See doc/fuse.txt section 5.
  * --config keeps the password out of argv, where ps can read it.

Supporting changes:

  * seeder: download grants may name a file (a file list, whose hash is not knowable in advance) or a byte range. A named identifier is accepted only in a CSND answering our own request -- a CGET from a peer still serves by hash and nothing else. Media type "*" allows a cache that serves arbitrary content.
  * util: uhub_cond_timedwait(), so a blocked request can notice its reader has gone away.
  * test: seed_put and filelist_peer, the fixtures the client-to-client path needed to be testable from a script at all.

Off by default; -DFUSE_SUPPORT=ON needs libfuse3 and libbz2. See doc/fuse.txt and uhub-fuse(1).